### PR TITLE
fix(game): survive the final frames of a snake's exit animation

### DIFF
--- a/src/TerminalSnake.App/Game/GameEngine.cs
+++ b/src/TerminalSnake.App/Game/GameEngine.cs
@@ -131,8 +131,8 @@ public sealed class GameEngine
     public FrameBuffer Render(Viewport viewport, TimeSpan now)
     {
         var buffer = new FrameBuffer(viewport.TerminalWidth, viewport.TerminalHeight);
-        var visibleBoard = ApplyAnimationSnapshot(_currentBoard, now);
-        _renderer.Render(buffer, visibleBoard, viewport, SelectedSnakeIndex);
+        var (visibleBoard, overlay) = ApplyAnimationSnapshot(_currentBoard, now);
+        _renderer.Render(buffer, visibleBoard, viewport, SelectedSnakeIndex, overlay);
         return buffer;
     }
 
@@ -268,16 +268,37 @@ public sealed class GameEngine
         _lastDemoMoveAt = now;
     }
 
-    private Board ApplyAnimationSnapshot(Board board, TimeSpan now)
+    private (Board Board, IReadOnlyDictionary<Cell, SnakeColor>? Overlay)
+        ApplyAnimationSnapshot(Board board, TimeSpan now)
     {
         var snapshot = _animation.Current(now);
         if (snapshot is null)
         {
-            return board;
+            return (board, null);
         }
+
         var original = board.Snakes[snapshot.Value.SnakeIndex];
-        var replaced = new Snake(snapshot.Value.Segments, original.Color);
-        var updated = board.Snakes.SetItem(snapshot.Value.SnakeIndex, replaced);
-        return board.WithSnakes(updated);
+        if (snapshot.Value.Segments.Length >= 2)
+        {
+            var replaced = new Snake(snapshot.Value.Segments, original.Color);
+            var updated = board.Snakes.SetItem(snapshot.Value.SnakeIndex, replaced);
+            return (board.WithSnakes(updated), null);
+        }
+
+        // Final frames of an exit animation: the snake has shrunk below the
+        // two-segment minimum Snake requires for a valid direction. Drop it
+        // from the board and paint the leftover segment (if any) as a plain
+        // overlay cell so the tail still animates cell-by-cell off-screen.
+        var trimmedSnakes = board.Snakes.RemoveAt(snapshot.Value.SnakeIndex);
+        var trimmedBoard = board.WithSnakes(trimmedSnakes);
+        if (snapshot.Value.Segments.Length == 1)
+        {
+            var overlay = new Dictionary<Cell, SnakeColor>
+            {
+                [snapshot.Value.Segments[0]] = original.Color,
+            };
+            return (trimmedBoard, overlay);
+        }
+        return (trimmedBoard, null);
     }
 }

--- a/src/TerminalSnake.App/Rendering/BoardRenderer.cs
+++ b/src/TerminalSnake.App/Rendering/BoardRenderer.cs
@@ -13,7 +13,12 @@ public sealed class BoardRenderer
     public const char BodyChar = '█';
     public const char EmptyChar = ' ';
 
-    public void Render(FrameBuffer buffer, Board board, Viewport viewport, int? selectedSnakeIndex = null)
+    public void Render(
+        FrameBuffer buffer,
+        Board board,
+        Viewport viewport,
+        int? selectedSnakeIndex = null,
+        IReadOnlyDictionary<Cell, SnakeColor>? overlay = null)
     {
         ArgumentNullException.ThrowIfNull(buffer);
         ArgumentNullException.ThrowIfNull(board);
@@ -30,6 +35,20 @@ public sealed class BoardRenderer
         for (var i = 0; i < board.Snakes.Length; i++)
         {
             DrawSnake(buffer, board.Snakes[i], viewport, isSelected: selectedSnakeIndex == i);
+        }
+        DrawOverlay(buffer, viewport, overlay);
+    }
+
+    private static void DrawOverlay(
+        FrameBuffer buffer, Viewport viewport, IReadOnlyDictionary<Cell, SnakeColor>? overlay)
+    {
+        if (overlay is null)
+        {
+            return;
+        }
+        foreach (var entry in overlay)
+        {
+            WriteCell(buffer, viewport, entry.Key, BodyChar, entry.Value, background: null);
         }
     }
 

--- a/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
+++ b/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
@@ -172,4 +172,28 @@ public sealed class GameEngineTests
         Assert.Equal(viewport.TerminalWidth, buffer.Width);
         Assert.Equal(viewport.TerminalHeight, buffer.Height);
     }
+
+    [Fact]
+    public void Render_does_not_throw_during_exit_animation_when_snake_shrinks_below_two_segments()
+    {
+        // Drives a snake through its full exit animation and asks for a
+        // render on every tick. Before the fix, the Snake constructor threw
+        // ArgumentException once the animation snapshot reached one or zero
+        // segments because Snake demands a minimum of two segments to infer
+        // its direction. See GitHub issue #3 for the original stack trace.
+        var engine = CreateEngine(animationStep: TimeSpan.FromMilliseconds(5));
+        var viewport = ViewportCalculator.Compute(
+            ViewportCalculator.MinimumWidth + 8,
+            ViewportCalculator.MinimumHeight + 8,
+            engine.Board.Size);
+
+        engine.HandleKey(new KeyEvent(ConsoleKey.Tab), TimeSpan.Zero);
+        engine.HandleKey(new KeyEvent(ConsoleKey.Enter), TimeSpan.Zero);
+
+        for (var ms = 0; ms <= 1_500; ms += 2)
+        {
+            engine.Tick(TimeSpan.FromMilliseconds(ms));
+            _ = engine.Render(viewport, TimeSpan.FromMilliseconds(ms));
+        }
+    }
 }

--- a/tests/TerminalSnake.Tests/Rendering/BoardRendererTests.cs
+++ b/tests/TerminalSnake.Tests/Rendering/BoardRendererTests.cs
@@ -106,4 +106,22 @@ public sealed class BoardRendererTests
         Assert.Contains("▶", snapshot);
         Assert.Contains("█", snapshot);
     }
+
+    [Fact]
+    public void Overlay_cells_are_painted_as_body_blocks_in_their_color()
+    {
+        var board = SimpleBoard(6, Snake(SnakeColor.Red, (0, 0), (1, 0)));
+        var viewport = ViewportCalculator.Compute(40, 12, 6);
+        var buffer = new FrameBuffer(viewport.TerminalWidth, viewport.TerminalHeight);
+        var overlay = new Dictionary<Cell, SnakeColor>
+        {
+            [new Cell(4, 4)] = SnakeColor.Green,
+        };
+        new BoardRenderer().Render(buffer, board, viewport, overlay: overlay);
+
+        var overlayBaseX = viewport.BoardOriginX + 4 * ViewportCalculator.CellCharWidth;
+        var overlayBaseY = viewport.BoardOriginY + 4 * ViewportCalculator.CellCharHeight;
+        Assert.Equal(BoardRenderer.BodyChar, buffer[overlayBaseX, overlayBaseY].Char);
+        Assert.Equal(SnakeColor.Green, buffer[overlayBaseX, overlayBaseY].Foreground);
+    }
 }


### PR DESCRIPTION
## Summary

When a snake exits the field, \`MoveEngine\` emits one animation frame per step. Each exit step drops a segment, so the final frames hold one and then zero segments — below \`Snake\`'s two-segment minimum invariant. The old \`ApplyAnimationSnapshot\` handed the shrinking segment list straight to \`new Snake(...)\`, which threw \`ArgumentException\` ("A snake needs at least 2 segments to determine its direction") mid-Spectre-refresh and aborted the game loop.

Split the render pipeline so the animated snake can be expressed without violating \`Snake\`'s invariant:

- \`ApplyAnimationSnapshot\` now returns \`(Board, overlay)\`. ≥ 2 segments → rebuild the snake as before. 1 segment → remove the snake from the board and emit the surviving cell as an overlay entry in its original colour. 0 segments → just remove the snake.
- \`BoardRenderer.Render\` accepts an optional overlay \`IReadOnlyDictionary<Cell, SnakeColor>\` and paints each entry as a body block in the given colour after the regular snake pass, preserving the visual cell-by-cell exit trail.

Closes #3

## Test plan
- [x] New regression: \`Render_does_not_throw_during_exit_animation_when_snake_shrinks_below_two_segments\` drives a snake through its full exit animation and asks for a render every tick. Fails on \`main\`, passes with this change.
- [x] New unit test: \`Overlay_cells_are_painted_as_body_blocks_in_their_color\`.
- [x] \`dotnet test\` — 207 passing.
- [x] \`./scripts/quality-gate.sh\` — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)