### PR TITLE
fix(input): switch raw-mode to direct tcgetattr/tcsetattr

### DIFF
--- a/src/TerminalSnake.App/Input/PosixTerminal.cs
+++ b/src/TerminalSnake.App/Input/PosixTerminal.cs
@@ -1,0 +1,85 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace TerminalSnake.Input;
+
+// Direct P/Invoke wrapper around POSIX termios. Used to put stdin into
+// character-at-a-time mode with echo disabled so the game loop can react
+// to single keystrokes like Tab without waiting for the user to press
+// Enter (which was the actual behaviour that survived #10's stty-based
+// attempt on macOS).
+//
+// Only macOS (Darwin) is implemented; other platforms leave the tty
+// alone and the app falls back to line-buffered input.
+[ExcludeFromCodeCoverage]
+internal static class PosixTerminal
+{
+    private const int StdinFileno = 0;
+    private const int TcsaNow = 0;
+
+    // Darwin termios constants (from <sys/termios.h>).
+    private const ulong DarwinIcanon = 0x00000100;
+    private const ulong DarwinEcho   = 0x00000008;
+    private const ulong DarwinEchonl = 0x00000010;
+    private const ulong DarwinIexten = 0x00000400;
+    private const int DarwinVmin = 16;
+    private const int DarwinVtime = 17;
+
+    private static bool _hasSaved;
+    private static TermiosDarwin _saved;
+
+    [StructLayout(LayoutKind.Sequential)]
+    private unsafe struct TermiosDarwin
+    {
+        public ulong c_iflag;
+        public ulong c_oflag;
+        public ulong c_cflag;
+        public ulong c_lflag;
+        public fixed byte c_cc[20];
+        public ulong c_ispeed;
+        public ulong c_ospeed;
+    }
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern unsafe int tcgetattr(int fd, TermiosDarwin* termios);
+
+    [DllImport("libc", SetLastError = true)]
+    private static extern unsafe int tcsetattr(int fd, int actions, TermiosDarwin* termios);
+
+    public static bool EnterRawMode()
+    {
+        if (!OperatingSystem.IsMacOS())
+        {
+            return false;
+        }
+        unsafe
+        {
+            TermiosDarwin current;
+            if (tcgetattr(StdinFileno, &current) != 0)
+            {
+                return false;
+            }
+            _saved = current;
+            _hasSaved = true;
+
+            current.c_lflag &= ~(DarwinIcanon | DarwinEcho | DarwinEchonl | DarwinIexten);
+            current.c_cc[DarwinVmin] = 1;
+            current.c_cc[DarwinVtime] = 0;
+            return tcsetattr(StdinFileno, TcsaNow, &current) == 0;
+        }
+    }
+
+    public static void Restore()
+    {
+        if (!OperatingSystem.IsMacOS() || !_hasSaved)
+        {
+            return;
+        }
+        unsafe
+        {
+            var copy = _saved;
+            tcsetattr(StdinFileno, TcsaNow, &copy);
+        }
+        _hasSaved = false;
+    }
+}

--- a/src/TerminalSnake.App/Input/PosixTerminal.cs
+++ b/src/TerminalSnake.App/Input/PosixTerminal.cs
@@ -82,4 +82,23 @@ internal static class PosixTerminal
         }
         _hasSaved = false;
     }
+
+    /// <summary>
+    /// Opens a FileStream over the controlling terminal, bypassing
+    /// <see cref="Console.OpenStandardInput"/>. On Unix, .NET wraps stdin
+    /// in a managed line-editing reader whenever the input is a tty — that
+    /// reader aggregates keystrokes until a newline no matter what the tty
+    /// is configured to. Reading <c>/dev/tty</c> directly goes straight
+    /// through the libc <c>read()</c> syscall and respects the termios
+    /// state set via <see cref="EnterRawMode"/>.
+    /// </summary>
+    public static Stream OpenTtyReadStream()
+    {
+        return new FileStream(
+            "/dev/tty",
+            FileMode.Open,
+            FileAccess.Read,
+            FileShare.ReadWrite,
+            bufferSize: 1);
+    }
 }

--- a/src/TerminalSnake.App/Input/TerminalMode.cs
+++ b/src/TerminalSnake.App/Input/TerminalMode.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace TerminalSnake.Input;
@@ -14,20 +13,18 @@ public static class TerminalEscapeSequences
 }
 
 // Flips the host tty out of canonical+echo mode so keystrokes reach the app
-// immediately, enables xterm mouse reporting, hides the cursor, and restores
-// the previous state on Dispose. Excluded from coverage because all its
-// behaviour depends on a live terminal; the argument-formatting is covered
-// indirectly by TerminalEscapeSequencesTests.
+// immediately, enables xterm mouse reporting, hides the cursor, and
+// restores the previous state on Dispose. Excluded from coverage because
+// all its behaviour depends on a live terminal.
 [ExcludeFromCodeCoverage]
 public sealed class TerminalMode : IDisposable
 {
     private bool _enabled;
-    private string? _savedPosixTty;
 
     public void Enable(TextWriter output)
     {
         ArgumentNullException.ThrowIfNull(output);
-        SwitchStdinToRaw();
+        PosixTerminal.EnterRawMode();
         output.Write(TerminalEscapeSequences.EnableMouse);
         output.Write(TerminalEscapeSequences.HideCursor);
         output.Flush();
@@ -43,74 +40,9 @@ public sealed class TerminalMode : IDisposable
         output.Write(TerminalEscapeSequences.ShowCursor);
         output.Write(TerminalEscapeSequences.DisableMouse);
         output.Flush();
-        RestoreStdin();
+        PosixTerminal.Restore();
         _enabled = false;
     }
 
     public void Dispose() => Disable(Console.Out);
-
-    private void SwitchStdinToRaw()
-    {
-        if (OperatingSystem.IsWindows())
-        {
-            // On Windows the default console is already line-buffered, but
-            // Console.ReadKey / the equivalent Win32 SetConsoleMode path is
-            // not exercised here. Left intentionally empty; tracked
-            // separately.
-            return;
-        }
-        _savedPosixTty = CaptureStty();
-        RunStty("-icanon -echo -isig min 1 time 0");
-    }
-
-    private void RestoreStdin()
-    {
-        if (OperatingSystem.IsWindows() || string.IsNullOrEmpty(_savedPosixTty))
-        {
-            return;
-        }
-        RunStty(_savedPosixTty);
-        _savedPosixTty = null;
-    }
-
-    private static string? CaptureStty()
-    {
-        try
-        {
-            using var proc = Process.Start(new ProcessStartInfo("/bin/stty", "-g")
-            {
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-            });
-            if (proc is null)
-            {
-                return null;
-            }
-            var state = proc.StandardOutput.ReadToEnd().Trim();
-            proc.WaitForExit(1000);
-            return string.IsNullOrWhiteSpace(state) ? null : state;
-        }
-        catch
-        {
-            return null;
-        }
-    }
-
-    private static void RunStty(string arguments)
-    {
-        try
-        {
-            using var proc = Process.Start(new ProcessStartInfo("/bin/stty", arguments)
-            {
-                RedirectStandardError = true,
-                UseShellExecute = false,
-            });
-            proc?.WaitForExit(1000);
-        }
-        catch
-        {
-            // Best effort — if stty is unavailable the game still runs, just in line mode.
-        }
-    }
 }

--- a/src/TerminalSnake.App/Program.cs
+++ b/src/TerminalSnake.App/Program.cs
@@ -143,7 +143,9 @@ internal static class Program
     private static void PumpStdin(ChannelWriter<InputEvent> writer, CancellationToken ct)
     {
         var parser = new BufferedInputParser();
-        var stdin = Console.OpenStandardInput();
+        var stdin = OperatingSystem.IsWindows()
+            ? Console.OpenStandardInput()
+            : PosixTerminal.OpenTtyReadStream();
         var buffer = new byte[128];
         while (!ct.IsCancellationRequested)
         {

--- a/src/TerminalSnake.App/TerminalSnake.App.csproj
+++ b/src/TerminalSnake.App/TerminalSnake.App.csproj
@@ -4,6 +4,8 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>TerminalSnake</RootNamespace>
     <AssemblyName>TerminalSnake.App</AssemblyName>
+    <!-- termios P/Invoke wrapper uses a fixed-size c_cc buffer. -->
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Supersedes the approach merged in #10. Manual testing on macOS Terminal showed that \`Process.Start(\"/bin/stty\", \"-icanon -echo ...\")\` did not actually change the parent's tty state — Tab keystrokes were still being line-buffered and only reached the engine together with Enter, which is why neither #1 nor #2 produced any visible change.

This PR replaces the subprocess path with a direct \`tcgetattr\`/\`tcsetattr\` P/Invoke against \`libc\`:

- \`PosixTerminal.EnterRawMode\` reads the current \`termios\`, stores it, clears \`ICANON\`, \`ECHO\`, \`ECHONL\`, \`IEXTEN\` on \`c_lflag\`, writes \`c_cc[VMIN]=1\` / \`c_cc[VTIME]=0\`, and writes the struct back.
- \`PosixTerminal.Restore\` writes the saved struct back, leaving the terminal in the state the app found it.
- \`ISIG\` stays enabled so Ctrl+C still produces \`SIGINT\` and \`Console.CancelKeyPress\` keeps working for clean shutdown.

The \`struct termios\` layout is specific to 64-bit macOS (\`tcflag_t\` = \`unsigned long\`, \`NCCS\` = 20). Linux and other POSIX variants use a different layout; they fall back to canonical mode for now — tracked separately.

\`AllowUnsafeBlocks\` is flipped on because the \`fixed byte c_cc[20]\` field requires it. \`PosixTerminal\` itself stays \`[ExcludeFromCodeCoverage]\` (its correctness can only be validated against a real tty).

Closes #11

## Prerequisite for #1 and #2

After this merges, rebase \`fix/1-selection-highlight\` and \`fix/2-live-display-jumps\` onto \`main\`. Tab should finally reach the engine on the first press and make the selection cue visible; echoed-input garbage that produced the #2 jumps should be gone.

## Test plan
- [x] \`dotnet build -c Release\` — clean.
- [x] \`dotnet test\` — 210 passing.
- [x] \`./scripts/quality-gate.sh\` — PASSED.
- [ ] **Manual on macOS**: start the game, press Tab once → selection cue appears without pressing Enter; press Q → terminal returns to normal (typing shows characters again).

🤖 Generated with [Claude Code](https://claude.com/claude-code)