### PR TITLE
feat(generation): scale snake length so later levels have long snakes

### DIFF
--- a/src/TerminalSnake.App/Generation/BoardGenerator.cs
+++ b/src/TerminalSnake.App/Generation/BoardGenerator.cs
@@ -7,11 +7,13 @@ public sealed class BoardGenerator
     public const int MaxSnakesPerBoard = 8;
     public const int MinBoardSize = 6;
     public const int MaxBoardSize = 16;
-    public const int MaxSegmentLength = 8;
+    public const int MaxSegmentLength = 14;
     public const int DefaultSolvableAttempts = 80;
 
-    private const int SnakePlacementAttempts = 60;
-    private const int MinSnakeLength = 3;
+    // Long-snake profiles make random-walk placement harder; allow more
+    // placement retries before failing a whole board attempt.
+    private const int SnakePlacementAttempts = 120;
+    private const int AbsoluteMinSnakeLength = 3;
 
     private static readonly Direction[] AllDirections =
     {
@@ -93,9 +95,12 @@ public sealed class BoardGenerator
                 continue;
             }
             var (head, second) = seed.Value;
-            var targetLength = random.Next(MinSnakeLength, profile.MaxSnakeLength + 1);
+            var targetLength = random.Next(profile.MinSnakeLength, profile.MaxSnakeLength + 1);
             var segments = GrowSnake(random, profile.Size, occupied, head, second, targetLength);
-            if (segments.Count >= MinSnakeLength)
+            // Reject snakes that couldn't reach the profile's minimum length —
+            // accepting a 3-segment snake when the target was 10 would quietly
+            // regress the "snakes must be longer" ask behind issue #13.
+            if (segments.Count >= profile.MinSnakeLength)
             {
                 return new Snake(segments, color);
             }
@@ -195,14 +200,19 @@ public sealed class BoardGenerator
         return new Board(profile.Size, snakes);
     }
 
-    internal sealed record DifficultyProfile(int Size, int SnakeCount, int MaxSnakeLength)
+    internal sealed record DifficultyProfile(int Size, int SnakeCount, int MinSnakeLength, int MaxSnakeLength)
     {
+        // Level 1 stays friendly (3-4 cell snakes on a 6x6). Snakes grow quickly
+        // from there so by ~level 7 the maximum passes 10 cells; boards widen
+        // in step so the density stays manageable for the solver.
         public static DifficultyProfile For(int levelIndex)
         {
-            var size = Math.Clamp(MinBoardSize + levelIndex / 3, MinBoardSize, MaxBoardSize);
-            var snakeCount = Math.Clamp(3 + levelIndex / 2, 3, MaxSnakesPerBoard);
-            var maxLen = Math.Clamp(3 + levelIndex / 4, MinSnakeLength, MaxSegmentLength);
-            return new DifficultyProfile(size, snakeCount, maxLen);
+            var size = Math.Clamp(MinBoardSize + levelIndex / 2, MinBoardSize, MaxBoardSize);
+            var snakeCount = Math.Clamp(3 + levelIndex / 3, 3, MaxSnakesPerBoard);
+            var minLen = Math.Clamp(AbsoluteMinSnakeLength + levelIndex / 4, AbsoluteMinSnakeLength, MaxSegmentLength);
+            var rawMax = AbsoluteMinSnakeLength + levelIndex;
+            var maxLen = Math.Clamp(Math.Max(rawMax, minLen + 1), AbsoluteMinSnakeLength + 1, MaxSegmentLength);
+            return new DifficultyProfile(size, snakeCount, minLen, maxLen);
         }
     }
 }

--- a/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
+++ b/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
@@ -208,16 +208,17 @@ public sealed class GameEngineTests
     [Fact]
     public void BuildViewport_tracks_new_board_size_after_a_level_up()
     {
-        // Level 2 generates a 6x6 board, level 3 jumps to 7x7. Drain level 2
-        // and confirm BuildViewport reports the new, larger board — the crash
-        // in issue #7 happened because a cached viewport still claimed 6.
-        var engine = CreateEngine(startLevel: 2, animationStep: TimeSpan.FromMilliseconds(1));
+        // Level 1 is 6x6, level 2 is 7x7 under the current difficulty
+        // profile. Drain level 1 and confirm BuildViewport reports the new,
+        // larger board — the crash in issue #7 happened because a cached
+        // viewport still claimed 6.
+        var engine = CreateEngine(startLevel: 1, animationStep: TimeSpan.FromMilliseconds(1));
         var beforeSize = engine.Board.Size;
         Assert.Equal(beforeSize, engine.BuildViewport(200, 80).BoardSide);
 
         DrainCurrentLevel(engine);
 
-        Assert.Equal(3, engine.LevelIndex);
+        Assert.Equal(2, engine.LevelIndex);
         var afterSize = engine.Board.Size;
         Assert.NotEqual(beforeSize, afterSize);
         Assert.Equal(afterSize, engine.BuildViewport(200, 80).BoardSide);
@@ -229,7 +230,7 @@ public sealed class GameEngineTests
         // Regression for issue #7: BoardRenderer rejects mismatched viewport
         // and board sizes. The fix is to rebuild the viewport every render
         // via BuildViewport so it always tracks the engine's current board.
-        var engine = CreateEngine(startLevel: 2, animationStep: TimeSpan.FromMilliseconds(1));
+        var engine = CreateEngine(startLevel: 1, animationStep: TimeSpan.FromMilliseconds(1));
         DrainCurrentLevel(engine);
         var viewport = engine.BuildViewport(200, 80);
         _ = engine.Render(viewport, TimeSpan.FromSeconds(1));

--- a/tests/TerminalSnake.Tests/Generation/BoardGeneratorTests.cs
+++ b/tests/TerminalSnake.Tests/Generation/BoardGeneratorTests.cs
@@ -74,4 +74,29 @@ public sealed class BoardGeneratorTests
         }
     }
 
+    [Fact]
+    public void Mid_level_boards_include_snakes_of_at_least_five_segments()
+    {
+        // Issue #13: from ~level 5 onwards at least one snake on most boards
+        // must be 5+ cells. Scan 10 seeds and require the claim to hold on
+        // at least one of them (generator randomness leaves room for the
+        // occasional all-short board).
+        var generator = new BoardGenerator();
+        var found = Enumerable.Range(0, 10)
+            .Select(seed => generator.Generate(6, seed))
+            .Any(b => b.Snakes.Any(s => s.Segments.Length >= 5));
+        Assert.True(found, "level 6 should be able to produce a 5+ cell snake");
+    }
+
+    [Fact]
+    public void High_level_boards_include_snakes_of_at_least_ten_segments()
+    {
+        // Issue #13: later levels should produce genuinely long snakes.
+        // Scan 10 seeds and require at least one to yield a 10+ cell snake.
+        var generator = new BoardGenerator();
+        var found = Enumerable.Range(0, 10)
+            .Select(seed => generator.Generate(12, seed))
+            .Any(b => b.Snakes.Any(s => s.Segments.Length >= 10));
+        Assert.True(found, "level 12 should be able to produce a 10+ cell snake");
+    }
 }


### PR DESCRIPTION
## Summary

Issue #13: snakes were capped at 8 cells and grew by one every four levels, so even late levels looked like early levels. This PR reshapes the difficulty profile so snakes get genuinely long.

- \`MaxSegmentLength\` rises from **8 → 14**.
- \`DifficultyProfile\` now carries both \`MinSnakeLength\` and \`MaxSnakeLength\`; the generator draws the target from that range and rejects snakes that couldn't reach the minimum (so a lucky 3-cell placement no longer silently satisfies a level that was asking for 10).
- New formulas:

  | parameter | formula | level 1 | level 7 | level 11+ |
  | --- | --- | --- | --- | --- |
  | size | \`clamp(6 + lvl/2, 6, 16)\` | 6 | 9 | 11–16 |
  | snake count | \`clamp(3 + lvl/3, 3, 8)\` | 3 | 5 | 6–8 |
  | min length | \`clamp(3 + lvl/4, 3, 14)\` | 3 | 4 | 5–14 |
  | max length | \`clamp(3 + lvl, 4, 14)\` | 4 | 10 | 14 |

- \`SnakePlacementAttempts\` bumped 60 → 120: long-target random walks on denser boards fail more often and need more retries.

Two new regression tests sweep 10 seeds per level:
- level 6 must be able to produce at least one 5+ cell snake
- level 12 must be able to produce at least one 10+ cell snake

Closes #13

## Test plan
- [x] \`dotnet test\` — 222 passing (including the 500-seed solvability stress test).
- [x] \`./scripts/quality-gate.sh\` — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)