### PR TITLE
feat(game): stop the enter-spam path to finishing a level

### DIFF
--- a/src/TerminalSnake.App/Game/GameEngine.cs
+++ b/src/TerminalSnake.App/Game/GameEngine.cs
@@ -20,6 +20,7 @@ public sealed class GameEngine
 
     private Board _currentBoard;
     private Board? _pendingBoardAfterAnimation;
+    private int _preAnimationSnakeCount;
     private Queue<int> _demoQueue = new();
     private TimeSpan _lastDemoMoveAt = TimeSpan.Zero;
 
@@ -215,18 +216,40 @@ public sealed class GameEngine
         {
             return;
         }
+        _preAnimationSnakeCount = _currentBoard.Snakes.Length;
         _pendingBoardAfterAnimation = outcome.ResultingBoard;
         _animation.Start(snakeIndex, outcome.Frames, now);
     }
 
     private void FinalizeAnimation()
     {
-        if (_pendingBoardAfterAnimation is not null)
-        {
-            _currentBoard = _pendingBoardAfterAnimation;
-            _pendingBoardAfterAnimation = null;
-        }
+        var snakeExited = CommitPendingBoard();
         _animation.Clear();
+        UpdateSelectionAfterFinalize(snakeExited);
+    }
+
+    private bool CommitPendingBoard()
+    {
+        if (_pendingBoardAfterAnimation is null)
+        {
+            return false;
+        }
+        var exited = _pendingBoardAfterAnimation.Snakes.Length < _preAnimationSnakeCount;
+        _currentBoard = _pendingBoardAfterAnimation;
+        _pendingBoardAfterAnimation = null;
+        return exited;
+    }
+
+    private void UpdateSelectionAfterFinalize(bool snakeExited)
+    {
+        if (snakeExited)
+        {
+            // Clear the selection after an exit so the player actively picks
+            // the next snake instead of hitting Enter until the board empties
+            // — see issue #14.
+            SelectedSnakeIndex = null;
+            return;
+        }
         if (SelectedSnakeIndex is int selected && selected >= _currentBoard.Snakes.Length)
         {
             SelectedSnakeIndex = _currentBoard.Snakes.Length > 0 ? 0 : null;

--- a/src/TerminalSnake.App/Generation/BoardGenerator.cs
+++ b/src/TerminalSnake.App/Generation/BoardGenerator.cs
@@ -48,17 +48,67 @@ public sealed class BoardGenerator
         }
 
         var profile = DifficultyProfile.For(levelIndex);
+        var requireChallenge = levelIndex >= 2;
         for (var attempt = 0; attempt < _solvableAttempts; attempt++)
         {
             var random = new Random(CombineSeed(seed, attempt));
-            var board = TryBuildBoard(random, profile);
-            if (board is not null && Solver.TrySolve(board) is not null)
+            var candidate = TryBuildAcceptableBoard(random, profile, requireChallenge);
+            if (candidate is not null)
             {
-                return board;
+                return candidate;
             }
         }
 
         return FallbackBoard(profile);
+    }
+
+    private static Board? TryBuildAcceptableBoard(Random random, DifficultyProfile profile, bool requireChallenge)
+    {
+        var board = TryBuildBoard(random, profile);
+        if (board is null)
+        {
+            return null;
+        }
+        if (requireChallenge && !HasInitiallyBlockedSnake(board))
+        {
+            return null;
+        }
+        return Solver.TrySolve(board) is null ? null : board;
+    }
+
+    /// <summary>
+    /// True if at least one snake cannot walk straight out of the field on
+    /// turn one because another snake's body sits in its forward path.
+    /// Rejecting boards where this is false avoids the "press Enter three
+    /// times, level done" flow reported in issue #14.
+    /// </summary>
+    private static bool HasInitiallyBlockedSnake(Board board)
+    {
+        foreach (var snake in board.Snakes)
+        {
+            if (IsForwardPathBlocked(board, snake))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static bool IsForwardPathBlocked(Board board, Snake snake)
+    {
+        var ownHead = snake.Head;
+        var delta = snake.Direction.Delta();
+        var cursor = ownHead + delta;
+        while (board.IsInside(cursor))
+        {
+            var occupant = board.OccupyingSnake(cursor);
+            if (occupant is int index && !ReferenceEquals(board.Snakes[index], snake))
+            {
+                return true;
+            }
+            cursor += delta;
+        }
+        return false;
     }
 
     private static int CombineSeed(int baseSeed, int attempt) =>

--- a/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
+++ b/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
@@ -236,6 +236,41 @@ public sealed class GameEngineTests
         _ = engine.Render(viewport, TimeSpan.FromSeconds(1));
     }
 
+    [Fact]
+    public void Selection_clears_after_a_snake_exits_so_enter_cannot_chain_removals()
+    {
+        // Issue #14: the engine used to leave SelectedSnakeIndex pointing at
+        // whichever snake slid into the exited snake's slot, so repeatedly
+        // hitting Enter emptied the board without the player having to
+        // think. Drive the solver until the first exit and assert the
+        // selection is cleared.
+        var engine = CreateEngine(animationStep: TimeSpan.FromMilliseconds(1));
+        var clock = TimeSpan.Zero;
+
+        while (engine.Board.Snakes.Length > 0)
+        {
+            var solution = Solver.TrySolve(engine.Board);
+            Assert.NotNull(solution);
+            Assert.NotEmpty(solution);
+
+            var before = engine.Board.Snakes.Length;
+            var snake = engine.Board.Snakes[solution[0]];
+            engine.HandleBoardClick(snake.Head.X, snake.Head.Y, clock);
+            while (engine.IsAnimating)
+            {
+                clock = clock.Add(TimeSpan.FromMilliseconds(2));
+                engine.Tick(clock);
+            }
+
+            if (engine.Board.Snakes.Length < before)
+            {
+                Assert.Null(engine.SelectedSnakeIndex);
+                return;
+            }
+        }
+        Assert.Fail("expected at least one snake to exit during the level");
+    }
+
     private static void DrainCurrentLevel(GameEngine engine)
     {
         // Stop as soon as Tick advances to the next level. Without this guard

--- a/tests/TerminalSnake.Tests/Generation/BoardGeneratorTests.cs
+++ b/tests/TerminalSnake.Tests/Generation/BoardGeneratorTests.cs
@@ -99,4 +99,41 @@ public sealed class BoardGeneratorTests
             .Any(b => b.Snakes.Any(s => s.Segments.Length >= 10));
         Assert.True(found, "level 12 should be able to produce a 10+ cell snake");
     }
+
+    [Theory]
+    [InlineData(2)]
+    [InlineData(5)]
+    [InlineData(10)]
+    public void Level_two_and_above_always_start_with_at_least_one_blocked_snake(int levelIndex)
+    {
+        // Issue #14: boards where every snake can walk straight out trivialise
+        // the puzzle. The generator should reject them from level 2 onwards.
+        var generator = new BoardGenerator();
+        for (var seed = 0; seed < 10; seed++)
+        {
+            var board = generator.Generate(levelIndex, seed);
+            Assert.True(
+                HasAnyInitiallyBlockedSnake(board),
+                $"level {levelIndex} seed {seed} has no initially blocked snake");
+        }
+    }
+
+    private static bool HasAnyInitiallyBlockedSnake(Board board)
+    {
+        foreach (var snake in board.Snakes)
+        {
+            var delta = snake.Direction.Delta();
+            var cursor = snake.Head + delta;
+            while (board.IsInside(cursor))
+            {
+                var occupant = board.OccupyingSnake(cursor);
+                if (occupant is int index && !ReferenceEquals(board.Snakes[index], snake))
+                {
+                    return true;
+                }
+                cursor += delta;
+            }
+        }
+        return false;
+    }
 }


### PR DESCRIPTION
## Summary

Issue #14: after a snake exited, \`GameEngine\` left \`SelectedSnakeIndex\` pointing at whichever snake had slid into that slot, so a board that happened to have no real blocking reduced to "Enter, Enter, Enter, done". The generator also didn't care whether the initial board had any blocking at all.

Two complementary changes:

- **Engine**: \`FinalizeAnimation\` now clears \`SelectedSnakeIndex\` whenever a snake actually exited during the animation (tracked via a \`_preAnimationSnakeCount\` snapshot). The player has to consciously Tab or click to pick the next snake before Enter/Space does anything. Commit helpers \`CommitPendingBoard\`/\`UpdateSelectionAfterFinalize\` keep the method under the complexity gate.
- **Generator**: from level 2 onwards, reject boards whose snakes all start with a clear forward ray. \`HasInitiallyBlockedSnake\` walks each snake's direction from the head and requires at least one foreign snake in the path. Level 1 stays unconstrained for learning. \`TryBuildAcceptableBoard\` absorbs the extra branches so \`Generate\` stays within the cyclomatic budget.

Regression tests:
- \`Selection_clears_after_a_snake_exits_so_enter_cannot_chain_removals\` drives the solver until the first exit and asserts the selection is null.
- \`Level_two_and_above_always_start_with_at_least_one_blocked_snake\` theory checks the invariant on 10 seeds each at level 2, 5, 10.

Closes #14

## Test plan
- [x] \`dotnet test\` — 226 passing (includes all 400+500 solvability seeds).
- [x] \`./scripts/quality-gate.sh\` — PASSED after refactoring Generate + FinalizeAnimation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)