### PR TITLE
fix(input): decode SS3 arrow sequences instead of quitting the app

### DIFF
--- a/src/TerminalSnake.App/Input/InputDecoder.cs
+++ b/src/TerminalSnake.App/Input/InputDecoder.cs
@@ -6,6 +6,7 @@ public static class InputDecoder
 {
     private const byte Esc = 0x1B;
     private const byte Csi = (byte)'[';
+    private const byte Ss3 = (byte)'O';
     private const byte Sgr = (byte)'<';
 
     public static int TryDecode(ReadOnlySpan<byte> buffer, out InputEvent? decoded, bool inputFlushed = false)
@@ -29,11 +30,16 @@ public static class InputDecoder
         {
             return TryEmitBareEscape(inputFlushed, out decoded);
         }
-        if (buffer[1] != Csi)
+        return buffer[1] switch
         {
-            decoded = new KeyEvent(ConsoleKey.Escape);
-            return 1;
-        }
+            Csi => DecodeCsiOrWait(buffer, out decoded),
+            Ss3 => DecodeSs3OrWait(buffer, out decoded),
+            _ => EmitBareEscape(out decoded),
+        };
+    }
+
+    private static int DecodeCsiOrWait(ReadOnlySpan<byte> buffer, out InputEvent? decoded)
+    {
         if (buffer.Length == 2)
         {
             decoded = null;
@@ -41,6 +47,36 @@ public static class InputDecoder
         }
         return DecodeCsiSequence(buffer, out decoded);
     }
+
+    private static int DecodeSs3OrWait(ReadOnlySpan<byte> buffer, out InputEvent? decoded)
+    {
+        // SS3 is the "application cursor keys" form many terminals emit for
+        // the arrow keys (ESC O A/B/C/D). Treating them as ESC + letter
+        // collapses to a "Q quit" miss-route that closed the whole app on
+        // the first arrow press — see issue #18.
+        if (buffer.Length == 2)
+        {
+            decoded = null;
+            return 0;
+        }
+        decoded = DecodeSs3Final(buffer[2]);
+        return 3;
+    }
+
+    private static int EmitBareEscape(out InputEvent? decoded)
+    {
+        decoded = new KeyEvent(ConsoleKey.Escape);
+        return 1;
+    }
+
+    private static InputEvent? DecodeSs3Final(byte value) => value switch
+    {
+        (byte)'A' => new KeyEvent(ConsoleKey.UpArrow),
+        (byte)'B' => new KeyEvent(ConsoleKey.DownArrow),
+        (byte)'C' => new KeyEvent(ConsoleKey.RightArrow),
+        (byte)'D' => new KeyEvent(ConsoleKey.LeftArrow),
+        _ => null,
+    };
 
     private static int TryEmitBareEscape(bool inputFlushed, out InputEvent? decoded)
     {

--- a/tests/TerminalSnake.Tests/Input/InputDecoderTests.cs
+++ b/tests/TerminalSnake.Tests/Input/InputDecoderTests.cs
@@ -135,6 +135,34 @@ public sealed class InputDecoderTests
         Assert.Equal(expected, click.Button);
     }
 
+    [Theory]
+    [InlineData('A', ConsoleKey.UpArrow)]
+    [InlineData('B', ConsoleKey.DownArrow)]
+    [InlineData('C', ConsoleKey.RightArrow)]
+    [InlineData('D', ConsoleKey.LeftArrow)]
+    public void Application_keypad_arrow_sequences_parse_correctly(char finalChar, ConsoleKey expected)
+    {
+        // Terminals that have "application cursor keys" enabled (DECCKM on)
+        // send ESC O X instead of ESC [ X for the arrow keys. Before the
+        // fix for issue #18 the decoder interpreted that as a bare Escape
+        // followed by stray letters, which in turn closed the app via the
+        // Q / Escape quit path.
+        var buffer = new[] { (byte)0x1B, (byte)'O', (byte)finalChar };
+        var consumed = InputDecoder.TryDecode(buffer, out var evt);
+        Assert.Equal(3, consumed);
+        var key = Assert.IsType<KeyEvent>(evt);
+        Assert.Equal(expected, key.Key);
+    }
+
+    [Fact]
+    public void Incomplete_ss3_sequence_consumes_nothing()
+    {
+        var buffer = new[] { (byte)0x1B, (byte)'O' };
+        var consumed = InputDecoder.TryDecode(buffer, out var evt);
+        Assert.Equal(0, consumed);
+        Assert.Null(evt);
+    }
+
     [Fact]
     public void Non_standard_escape_prefix_treated_as_escape_key()
     {


### PR DESCRIPTION
## Summary

Issue #18: the first arrow key press silently closed the app.

### Root cause

Many terminals have "application cursor keys" (DECCKM) enabled and transmit arrow keys as \`ESC O A\` / \`B\` / \`C\` / \`D\` (SS3 form) instead of \`ESC [ A\` / … (CSI form). The decoder only knew about the CSI form, so it interpreted the \`ESC O A\` trio as three separate tokens:

1. \`ESC\` — treated as "bare Escape key" (because the second byte was not \`[\`),
2. shift-\`O\`,
3. shift-\`A\`.

\`Program.HandleEvent\`'s quit branch matches \`ConsoleKey.Escape\` → \`cts.Cancel()\` → game exits.

### Fix

Teach the decoder about the SS3 prefix:

```
ESC O A → UpArrow
ESC O B → DownArrow
ESC O C → RightArrow
ESC O D → LeftArrow
```

An incomplete \`ESC O\` waits for the third byte the same way \`ESC [\` does. Unrecognised prefixes (anything other than CSI or SS3 after Esc) still emit a plain Escape, so hitting Esc alone continues to quit.

\`DecodeEscapeSequence\` is split into three helpers to stay under the cyclomatic gate after the new branch.

Closes #18

## Test plan
- [x] Theory over the four arrow letters asserting the SS3 path emits the right \`ConsoleKey\`.
- [x] Incomplete \`ESC O\` asserts zero consumed bytes / no event until the final byte arrives.
- [x] \`dotnet test\` — 278 passing.
- [x] \`./scripts/quality-gate.sh\` — PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)