### PR TITLE
fix(game): suppress selection highlight during snake exit animation

### DIFF
--- a/src/TerminalSnake.App/Game/GameEngine.cs
+++ b/src/TerminalSnake.App/Game/GameEngine.cs
@@ -184,8 +184,8 @@ public sealed class GameEngine
     public FrameBuffer Render(Viewport viewport, TimeSpan now)
     {
         var buffer = new FrameBuffer(viewport.TerminalWidth, viewport.TerminalHeight);
-        var (visibleBoard, overlay) = ApplyAnimationSnapshot(_currentBoard, now);
-        _renderer.Render(buffer, visibleBoard, viewport, SelectedSnakeIndex, overlay);
+        var (visibleBoard, overlay, effectiveSelection) = ApplyAnimationSnapshot(_currentBoard, now);
+        _renderer.Render(buffer, visibleBoard, viewport, effectiveSelection, overlay);
         _hudRenderer.Render(buffer, viewport, new HudModel(LevelIndex, Mode, HelpVisible, _hudStrings));
         return buffer;
     }
@@ -440,13 +440,13 @@ public sealed class GameEngine
         _lastDemoMoveAt = now;
     }
 
-    private (Board Board, IReadOnlyDictionary<Cell, SnakeColor>? Overlay)
+    private (Board Board, IReadOnlyDictionary<Cell, SnakeColor>? Overlay, int? Selection)
         ApplyAnimationSnapshot(Board board, TimeSpan now)
     {
         var snapshot = _animation.Current(now);
         if (snapshot is null)
         {
-            return (board, null);
+            return (board, null, SelectedSnakeIndex);
         }
 
         var original = board.Snakes[snapshot.Value.SnakeIndex];
@@ -454,13 +454,17 @@ public sealed class GameEngine
         {
             var replaced = new Snake(snapshot.Value.Segments, original.Color);
             var updated = board.Snakes.SetItem(snapshot.Value.SnakeIndex, replaced);
-            return (board.WithSnakes(updated), null);
+            return (board.WithSnakes(updated), null, SelectedSnakeIndex);
         }
 
         // Final frames of an exit animation: the snake has shrunk below the
         // two-segment minimum Snake requires for a valid direction. Drop it
         // from the board and paint the leftover segment (if any) as a plain
         // overlay cell so the tail still animates cell-by-cell off-screen.
+        // Suppress the selection highlight too — the exiting snake's slot
+        // has been filled by whichever snake shifted down, and highlighting
+        // *that* one for a couple of frames before FinalizeAnimation clears
+        // the selection produces a flicker (#29).
         var trimmedSnakes = board.Snakes.RemoveAt(snapshot.Value.SnakeIndex);
         var trimmedBoard = board.WithSnakes(trimmedSnakes);
         if (snapshot.Value.Segments.Length == 1)
@@ -469,8 +473,8 @@ public sealed class GameEngine
             {
                 [snapshot.Value.Segments[0]] = original.Color,
             };
-            return (trimmedBoard, overlay);
+            return (trimmedBoard, overlay, null);
         }
-        return (trimmedBoard, null);
+        return (trimmedBoard, null, null);
     }
 }

--- a/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
+++ b/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
@@ -437,6 +437,58 @@ public sealed class GameEngineTests
     }
 
     [Fact]
+    public void Other_snakes_are_never_rendered_as_selected_during_an_exit_animation()
+    {
+        // Issue #29: when the selected snake exits, the animation's final
+        // frames trim it from the rendered board so remaining snakes shift
+        // down an index. Without the fix the renderer would briefly match
+        // the now-vacated selection index against whichever snake slid into
+        // that slot, highlighting the wrong snake for a frame or two before
+        // FinalizeAnimation cleared the selection. That shows as a flicker.
+        var engine = CreateEngine(animationStep: TimeSpan.FromMilliseconds(5));
+        Assert.True(engine.Board.Snakes.Length >= 2);
+
+        // Snapshot every other snake's body-cell positions — those cells
+        // never move during an animation of a different snake, so any ▓
+        // (SelectedBodyChar) appearing there must be a mis-highlight.
+        var otherCells = new List<(int X, int Y)>();
+        var animatedIndex = 0;
+        for (var i = 0; i < engine.Board.Snakes.Length; i++)
+        {
+            if (i == animatedIndex)
+            {
+                continue;
+            }
+            var snake = engine.Board.Snakes[i];
+            for (var s = 1; s < snake.Segments.Length; s++)
+            {
+                otherCells.Add((snake.Segments[s].X, snake.Segments[s].Y));
+            }
+        }
+
+        var head = engine.Board.Snakes[animatedIndex].Head;
+        engine.HandleBoardClick(head.X, head.Y, TimeSpan.Zero);
+
+        var viewport = engine.BuildViewport(200, 80);
+        for (var ms = 0; ms <= 1_500; ms += 2)
+        {
+            var now = TimeSpan.FromMilliseconds(ms);
+            engine.Tick(now);
+            var buffer = engine.Render(viewport, now);
+            foreach (var cell in otherCells)
+            {
+                var bx = viewport.BoardOriginX + cell.X * ViewportCalculator.CellCharWidth;
+                var by = viewport.BoardOriginY + cell.Y * ViewportCalculator.CellCharHeight;
+                Assert.NotEqual(BoardRenderer.SelectedBodyChar, buffer[bx, by].Char);
+            }
+            if (!engine.IsAnimating)
+            {
+                break;
+            }
+        }
+    }
+
+    [Fact]
     public void Selection_clears_after_a_snake_exits_so_enter_cannot_chain_removals()
     {
         // Issue #14: the engine used to leave SelectedSnakeIndex pointing at


### PR DESCRIPTION
## Summary
- When a snake exits, `ApplyAnimationSnapshot` removes it from the rendered board, which shifts the remaining snakes down an index. The unchanged `SelectedSnakeIndex` then matched whichever snake slid into the now-vacated slot, so that snake got the selection highlight (outlined head, ▓ body, reverse-video) for a couple of frames before `FinalizeAnimation` cleared the selection. The reporter saw this as a flicker.
- `ApplyAnimationSnapshot` now also returns an effective-selection value. During the exit-tail frames (<2 segments) it collapses to `null`, so the renderer paints no highlight. Internal state (`SelectedSnakeIndex`) still clears in `UpdateSelectionAfterFinalize` afterwards — this only decouples the visual highlight from the stale index.

Closes #29

## Test plan
- [x] `Other_snakes_are_never_rendered_as_selected_during_an_exit_animation` — drives an exit animation and asserts `BoardRenderer.SelectedBodyChar` never appears on any other snake's body cells across the whole animation. Verified to fail without the fix (with `SelectedSnakeIndex` left in place the buffer reports `▓` on a neighbour during the exit tail).
- [x] Full quality gate: 279/279 passing, line & branch thresholds clear, no complexity/CRAP regressions.