### PR TITLE
feat(input): clear the terminal when the app exits

### DIFF
--- a/src/TerminalSnake.App/Input/TerminalMode.cs
+++ b/src/TerminalSnake.App/Input/TerminalMode.cs
@@ -10,6 +10,9 @@ public static class TerminalEscapeSequences
     public const string DisableMouse = "\x1b[?1006l\x1b[?1000l";
     public const string HideCursor = "\x1b[?25l";
     public const string ShowCursor = "\x1b[?25h";
+    // Clear the visible screen and move the cursor home. Emitted on
+    // shutdown so the board is not left on the terminal after quit (#22).
+    public const string ClearScreen = "\x1b[2J\x1b[H";
 }
 
 // Flips the host tty out of canonical+echo mode so keystrokes reach the app
@@ -37,6 +40,7 @@ public sealed class TerminalMode : IDisposable
         {
             return;
         }
+        output.Write(TerminalEscapeSequences.ClearScreen);
         output.Write(TerminalEscapeSequences.ShowCursor);
         output.Write(TerminalEscapeSequences.DisableMouse);
         output.Flush();

--- a/tests/TerminalSnake.Tests/Input/TerminalEscapeSequencesTests.cs
+++ b/tests/TerminalSnake.Tests/Input/TerminalEscapeSequencesTests.cs
@@ -24,4 +24,12 @@ public sealed class TerminalEscapeSequencesTests
         Assert.Equal("\x1b[?25l", TerminalEscapeSequences.HideCursor);
         Assert.Equal("\x1b[?25h", TerminalEscapeSequences.ShowCursor);
     }
+
+    [Fact]
+    public void Clear_screen_sequence_wipes_the_screen_and_homes_the_cursor()
+    {
+        // Shutdown path emits this so the game board is not left on the
+        // terminal when the player quits (#22). CSI 2J clears, CSI H homes.
+        Assert.Equal("\x1b[2J\x1b[H", TerminalEscapeSequences.ClearScreen);
+    }
 }


### PR DESCRIPTION
## Summary
- When the player quits (Q / Esc / Ctrl-C), the last rendered game frame stayed on the terminal until the next shell command scrolled it away. It felt like the app had crashed rather than shut down cleanly.
- `TerminalMode.Disable` now writes `CSI 2J CSI H` (clear + home) before re-enabling the cursor and tearing down mouse reporting. The POSIX raw-mode restore still runs last, so the tty ends up in the exact state it was in before `Enable`.

Closes #22

## Test plan
- [x] `Clear_screen_sequence_wipes_the_screen_and_homes_the_cursor` — asserts the constant equals `\x1b[2J\x1b[H`.
- [x] Full quality gate passes (279/279).
- [ ] Manual smoke test: launch the game, press Q, terminal is blank and the shell prompt returns at the top.