### PR TITLE
feat(rendering): frame the play area with a visible board border

### DIFF
--- a/src/TerminalSnake.App/Rendering/BoardRenderer.cs
+++ b/src/TerminalSnake.App/Rendering/BoardRenderer.cs
@@ -10,6 +10,14 @@ public sealed class BoardRenderer
     public const char BorderCornerTopRight = '┐';
     public const char BorderCornerBottomLeft = '└';
     public const char BorderCornerBottomRight = '┘';
+    // Double-line glyphs frame the actual play area so the exit edges are
+    // visually distinct from the outer terminal frame (issue #24).
+    public const char BoardBorderHorizontal = '═';
+    public const char BoardBorderVertical = '║';
+    public const char BoardBorderCornerTopLeft = '╔';
+    public const char BoardBorderCornerTopRight = '╗';
+    public const char BoardBorderCornerBottomLeft = '╚';
+    public const char BoardBorderCornerBottomRight = '╝';
     public const char BodyChar = '█';
     public const char SelectedBodyChar = '▓';
     public const char EmptyChar = ' ';
@@ -32,12 +40,49 @@ public sealed class BoardRenderer
 
         buffer.Clear();
         DrawFrame(buffer, viewport);
+        DrawBoardBorder(buffer, viewport);
         ClearBoardArea(buffer, viewport);
         for (var i = 0; i < board.Snakes.Length; i++)
         {
             DrawSnake(buffer, board.Snakes[i], viewport, isSelected: selectedSnakeIndex == i);
         }
         DrawOverlay(buffer, viewport, overlay);
+    }
+
+    private static void DrawBoardBorder(FrameBuffer buffer, Viewport viewport)
+    {
+        var topRow = viewport.BoardOriginY - 1;
+        var bottomRow = viewport.BoardOriginY + viewport.BoardCharHeight;
+        var leftCol = viewport.BoardOriginX - 1;
+        var rightCol = viewport.BoardOriginX + viewport.BoardCharWidth;
+        TrySetInsideFrame(buffer, leftCol, topRow, BoardBorderCornerTopLeft);
+        TrySetInsideFrame(buffer, rightCol, topRow, BoardBorderCornerTopRight);
+        TrySetInsideFrame(buffer, leftCol, bottomRow, BoardBorderCornerBottomLeft);
+        TrySetInsideFrame(buffer, rightCol, bottomRow, BoardBorderCornerBottomRight);
+        for (var x = viewport.BoardOriginX; x < rightCol; x++)
+        {
+            TrySetInsideFrame(buffer, x, topRow, BoardBorderHorizontal);
+            TrySetInsideFrame(buffer, x, bottomRow, BoardBorderHorizontal);
+        }
+        for (var y = viewport.BoardOriginY; y < bottomRow; y++)
+        {
+            TrySetInsideFrame(buffer, leftCol, y, BoardBorderVertical);
+            TrySetInsideFrame(buffer, rightCol, y, BoardBorderVertical);
+        }
+    }
+
+    private static void TrySetInsideFrame(FrameBuffer buffer, int x, int y, char ch)
+    {
+        // At minimum viewport size the board sits flush against the outer
+        // terminal frame on the left and right, so the border would overwrite
+        // the frame chars and chew a gap in the outer rectangle. Skip any
+        // cell that is on the frame edge; the frame already marks the play
+        // boundary there.
+        if (x <= 0 || x >= buffer.Width - 1 || y <= 0 || y >= buffer.Height - 1)
+        {
+            return;
+        }
+        buffer.Set(x, y, ch);
     }
 
     private static void DrawOverlay(

--- a/tests/TerminalSnake.Tests/Rendering/BoardRendererTests.cs
+++ b/tests/TerminalSnake.Tests/Rendering/BoardRendererTests.cs
@@ -159,6 +159,55 @@ public sealed class BoardRendererTests
     }
 
     [Fact]
+    public void Board_border_is_drawn_around_the_play_area_when_viewport_has_slack()
+    {
+        // Issue #24: the outer terminal frame is several cells away from the
+        // play area on spacious terminals, so the actual edge where snakes
+        // exit needs its own visible border. With a taller/wider viewport
+        // than the minimum, the double-line box lands in padding space.
+        var board = SimpleBoard(6, Snake(SnakeColor.Red, (0, 0), (1, 0)));
+        var viewport = ViewportCalculator.Compute(60, 20, 6);
+        var buffer = new FrameBuffer(viewport.TerminalWidth, viewport.TerminalHeight);
+        new BoardRenderer().Render(buffer, board, viewport);
+
+        var topRow = viewport.BoardOriginY - 1;
+        var bottomRow = viewport.BoardOriginY + viewport.BoardCharHeight;
+        var leftCol = viewport.BoardOriginX - 1;
+        var rightCol = viewport.BoardOriginX + viewport.BoardCharWidth;
+        Assert.Equal(BoardRenderer.BoardBorderCornerTopLeft, buffer[leftCol, topRow].Char);
+        Assert.Equal(BoardRenderer.BoardBorderCornerTopRight, buffer[rightCol, topRow].Char);
+        Assert.Equal(BoardRenderer.BoardBorderCornerBottomLeft, buffer[leftCol, bottomRow].Char);
+        Assert.Equal(BoardRenderer.BoardBorderCornerBottomRight, buffer[rightCol, bottomRow].Char);
+        Assert.Equal(BoardRenderer.BoardBorderHorizontal, buffer[viewport.BoardOriginX + 2, topRow].Char);
+        Assert.Equal(BoardRenderer.BoardBorderVertical, buffer[leftCol, viewport.BoardOriginY + 2].Char);
+    }
+
+    [Fact]
+    public void Board_border_never_overwrites_the_outer_terminal_frame()
+    {
+        // At minimum viewport size the board is flush against the outer
+        // frame on the left and right. The board border must not eat into
+        // the frame glyphs — those are what the player sees as the left/
+        // right play-area edge in that layout.
+        var board = SimpleBoard(5, Snake(SnakeColor.Red, (0, 0), (1, 0)));
+        var viewport = ViewportCalculator.Compute(
+            ViewportCalculator.MinimumWidth,
+            ViewportCalculator.MinimumHeight,
+            5);
+        var buffer = new FrameBuffer(viewport.TerminalWidth, viewport.TerminalHeight);
+        new BoardRenderer().Render(buffer, board, viewport);
+
+        Assert.Equal(BoardRenderer.BorderCornerTopLeft, buffer[0, 0].Char);
+        Assert.Equal(BoardRenderer.BorderCornerTopRight, buffer[viewport.TerminalWidth - 1, 0].Char);
+        Assert.Equal(BoardRenderer.BorderCornerBottomLeft, buffer[0, viewport.TerminalHeight - 1].Char);
+        Assert.Equal(BoardRenderer.BorderCornerBottomRight,
+            buffer[viewport.TerminalWidth - 1, viewport.TerminalHeight - 1].Char);
+        Assert.Equal(BoardRenderer.BorderVertical, buffer[0, viewport.BoardOriginY].Char);
+        Assert.Equal(BoardRenderer.BorderVertical,
+            buffer[viewport.TerminalWidth - 1, viewport.BoardOriginY].Char);
+    }
+
+    [Fact]
     public void Overlay_cells_are_painted_as_body_blocks_in_their_color()
     {
         var board = SimpleBoard(6, Snake(SnakeColor.Red, (0, 0), (1, 0)));


### PR DESCRIPTION
## Summary
- On spacious terminals the outer frame is several cells away from the grid, so the actual edge where snakes exit had no visible marker — snakes just faded into empty padding.
- Added a double-line box (╔═╗ ║ ╚═╝) that hugs the play area. It is drawn in `BoardRenderer.Render` between the outer frame and the snake draw pass, so exit-animation snake segments still paint over it (giving the sense of the snake pushing through the wall).
- At minimum viewport size the board is flush against the outer frame on the left/right; the new `TrySetInsideFrame` skips any cell on row/col 0 or the last row/col so the outer rectangle stays intact and the player just sees the single frame on those edges.

Closes #24

## Test plan
- [x] `Board_border_is_drawn_around_the_play_area_when_viewport_has_slack` — renders a 60×20 viewport for a 6×6 board and asserts the corner, horizontal, and vertical glyphs land at the expected positions.
- [x] `Board_border_never_overwrites_the_outer_terminal_frame` — renders at minimum viewport and asserts the outer frame corners/verticals are still the single-line glyphs (not overwritten by the double-line board border).
- [x] Full quality gate passes (281/281).