### PR TITLE
feat(game): digit keys jump to a specific level

### DIFF
--- a/src/TerminalSnake.App/Game/GameEngine.cs
+++ b/src/TerminalSnake.App/Game/GameEngine.cs
@@ -253,7 +253,40 @@ public sealed class GameEngine
         if (key.Key == ConsoleKey.R)
         {
             RestartLevel();
+            return;
         }
+        if (TryMapDigitToLevel(key.Key) is int jumpLevel)
+        {
+            JumpToLevel(jumpLevel);
+        }
+    }
+
+    // Digit keys 1..9 jump to the matching tutorial level, 0 jumps to
+    // level 10 — the end of the handcrafted levels, which is also the
+    // jumping-off point into the procedural generator. Lets the player
+    // skip the easy intro levels when they just want harder puzzles
+    // (#25). Returns null for any non-digit key.
+    private static int? TryMapDigitToLevel(ConsoleKey key)
+    {
+        if (key >= ConsoleKey.D1 && key <= ConsoleKey.D9)
+        {
+            return key - ConsoleKey.D0;
+        }
+        if (key == ConsoleKey.D0)
+        {
+            return 10;
+        }
+        return null;
+    }
+
+    private void JumpToLevel(int levelIndex)
+    {
+        LevelIndex = levelIndex;
+        _currentBoard = _levels.LoadLevel(levelIndex);
+        _pendingBoardAfterAnimation = null;
+        _animation.Clear();
+        _demoQueue.Clear();
+        SelectedSnakeIndex = null;
     }
 
     private static Direction? TryMapArrowToDirection(ConsoleKey key) => key switch

--- a/src/TerminalSnake.App/Game/GameEngine.cs
+++ b/src/TerminalSnake.App/Game/GameEngine.cs
@@ -235,30 +235,55 @@ public sealed class GameEngine
 
     private void DispatchGameplayKey(KeyEvent key, TimeSpan now)
     {
+        if (TryHandleSelectionKey(key))
+        {
+            return;
+        }
+        if (TryHandleActivationKey(key, now))
+        {
+            return;
+        }
+        TryHandleLevelControlKey(key);
+    }
+
+    private bool TryHandleSelectionKey(KeyEvent key)
+    {
         if (key.Key == ConsoleKey.Tab)
         {
             CycleSelection(key.Shift ? -1 : +1);
-            return;
+            return true;
         }
         if (TryMapArrowToDirection(key.Key) is Direction direction)
         {
             SelectNearestSnakeInDirection(direction);
-            return;
+            return true;
         }
+        return false;
+    }
+
+    private bool TryHandleActivationKey(KeyEvent key, TimeSpan now)
+    {
         if (IsTriggerKey(key.Key))
         {
             TriggerSelectedSnake(now);
-            return;
+            return true;
         }
+        return false;
+    }
+
+    private bool TryHandleLevelControlKey(KeyEvent key)
+    {
         if (key.Key == ConsoleKey.R)
         {
             RestartLevel();
-            return;
+            return true;
         }
         if (TryMapDigitToLevel(key.Key) is int jumpLevel)
         {
             JumpToLevel(jumpLevel);
+            return true;
         }
+        return false;
     }
 
     // Digit keys 1..9 jump to the matching tutorial level, 0 jumps to

--- a/src/TerminalSnake.App/Rendering/HudLocalization.cs
+++ b/src/TerminalSnake.App/Rendering/HudLocalization.cs
@@ -10,7 +10,8 @@ public sealed record HudStrings(
     string HelpR,
     string HelpH,
     string HelpD,
-    string HelpQ);
+    string HelpQ,
+    string HelpLevels);
 
 public static class HudLocalization
 {
@@ -32,7 +33,8 @@ public static class HudLocalization
                 HelpR: "R — restart level",
                 HelpH: "H — toggle help",
                 HelpD: "D — re-enable auto-play",
-                HelpQ: "Q / Esc — quit"),
+                HelpQ: "Q / Esc — quit",
+                HelpLevels: "1-9, 0 — jump to level (0 = 10)"),
             ["de"] = new(
                 Title: "TerminalSnake",
                 LevelLabel: "Level",
@@ -43,7 +45,8 @@ public static class HudLocalization
                 HelpR: "R — Level neu starten",
                 HelpH: "H — Hilfe ein-/ausblenden",
                 HelpD: "D — Auto-Spiel aktivieren",
-                HelpQ: "Q / Esc — beenden"),
+                HelpQ: "Q / Esc — beenden",
+                HelpLevels: "1-9, 0 — Level springen (0 = 10)"),
             ["fr"] = new(
                 Title: "TerminalSnake",
                 LevelLabel: "Niveau",
@@ -54,7 +57,8 @@ public static class HudLocalization
                 HelpR: "R — recommencer le niveau",
                 HelpH: "H — afficher l'aide",
                 HelpD: "D — réactiver la démonstration",
-                HelpQ: "Q / Échap — quitter"),
+                HelpQ: "Q / Échap — quitter",
+                HelpLevels: "1-9, 0 — aller au niveau (0 = 10)"),
             ["es"] = new(
                 Title: "TerminalSnake",
                 LevelLabel: "Nivel",
@@ -65,7 +69,8 @@ public static class HudLocalization
                 HelpR: "R — reiniciar nivel",
                 HelpH: "H — mostrar ayuda",
                 HelpD: "D — reactivar la demostración",
-                HelpQ: "Q / Esc — salir"),
+                HelpQ: "Q / Esc — salir",
+                HelpLevels: "1-9, 0 — saltar al nivel (0 = 10)"),
             ["it"] = new(
                 Title: "TerminalSnake",
                 LevelLabel: "Livello",
@@ -76,7 +81,8 @@ public static class HudLocalization
                 HelpR: "R — ricomincia livello",
                 HelpH: "H — mostra aiuto",
                 HelpD: "D — riattiva la dimostrazione",
-                HelpQ: "Q / Esc — esci"),
+                HelpQ: "Q / Esc — esci",
+                HelpLevels: "1-9, 0 — salta al livello (0 = 10)"),
             ["pt"] = new(
                 Title: "TerminalSnake",
                 LevelLabel: "Nível",
@@ -87,7 +93,8 @@ public static class HudLocalization
                 HelpR: "R — reiniciar nível",
                 HelpH: "H — alternar ajuda",
                 HelpD: "D — reativar a reprodução automática",
-                HelpQ: "Q / Esc — sair"),
+                HelpQ: "Q / Esc — sair",
+                HelpLevels: "1-9, 0 — ir para o nível (0 = 10)"),
             ["nl"] = new(
                 Title: "TerminalSnake",
                 LevelLabel: "Level",
@@ -98,7 +105,8 @@ public static class HudLocalization
                 HelpR: "R — level herstarten",
                 HelpH: "H — hulp tonen",
                 HelpD: "D — auto-modus herinschakelen",
-                HelpQ: "Q / Esc — afsluiten"),
+                HelpQ: "Q / Esc — afsluiten",
+                HelpLevels: "1-9, 0 — naar level springen (0 = 10)"),
         };
 
     public static HudStrings Default => Locales[Fallback];

--- a/src/TerminalSnake.App/Rendering/HudRenderer.cs
+++ b/src/TerminalSnake.App/Rendering/HudRenderer.cs
@@ -45,10 +45,11 @@ public sealed class HudRenderer
         // Split the legend across the two padding rows that frame the
         // board — the full text does not fit on narrower terminals and
         // would get clipped mid-item otherwise. Top padding's second row
-        // carries the selection + release shortcuts; the row just above
-        // "Press H for help" carries the remaining three.
+        // carries the selection + release shortcuts plus the level jump;
+        // the row just above "Press H for help" carries the remaining
+        // utility keys.
         var strings = model.Strings;
-        var selectionReleaseLine = $"{strings.HelpTab}   {strings.HelpEnter}";
+        var selectionReleaseLine = $"{strings.HelpTab}   {strings.HelpEnter}   {strings.HelpLevels}";
         var utilityLine = $"{strings.HelpR}   {strings.HelpH}   {strings.HelpD}   {strings.HelpQ}";
         WriteText(buffer, x: 1, y: viewport.TopHudRow + 1, selectionReleaseLine);
         WriteText(buffer, x: 1, y: viewport.BottomHudRow - 1, utilityLine);

--- a/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
+++ b/tests/TerminalSnake.Tests/Game/GameEngineTests.cs
@@ -255,6 +255,36 @@ public sealed class GameEngineTests
         Assert.True(afterCount <= originalCount);
     }
 
+    [Theory]
+    [InlineData(ConsoleKey.D1, 1)]
+    [InlineData(ConsoleKey.D2, 2)]
+    [InlineData(ConsoleKey.D5, 5)]
+    [InlineData(ConsoleKey.D9, 9)]
+    [InlineData(ConsoleKey.D0, 10)]
+    public void Digit_keys_jump_to_the_matching_level(ConsoleKey digit, int expectedLevel)
+    {
+        // Issue #25: letting the player skip the intro levels on demand.
+        // Pressing 1..9 jumps to that level; 0 jumps to level 10 (the end
+        // of the handcrafted levels).
+        var engine = CreateEngine(startLevel: 1);
+        engine.HandleKey(new KeyEvent(digit), TimeSpan.Zero);
+        Assert.Equal(expectedLevel, engine.LevelIndex);
+    }
+
+    [Fact]
+    public void Digit_jump_replaces_the_current_board_and_clears_selection()
+    {
+        var engine = CreateEngine(startLevel: 1);
+        engine.HandleKey(new KeyEvent(ConsoleKey.Tab), TimeSpan.Zero);
+        Assert.NotNull(engine.SelectedSnakeIndex);
+        var level1Board = engine.Board;
+
+        engine.HandleKey(new KeyEvent(ConsoleKey.D5), TimeSpan.FromMilliseconds(10));
+        Assert.Equal(5, engine.LevelIndex);
+        Assert.Null(engine.SelectedSnakeIndex);
+        Assert.NotEqual(level1Board, engine.Board);
+    }
+
     [Fact]
     public void R_restarts_the_current_level()
     {


### PR DESCRIPTION
## Summary
- Issue #25: the player had no way to skip the intro levels — someone who just wanted a harder puzzle had to grind through the handcrafted sequence each launch.
- Pressing `1`..`9` now jumps the engine to that level; `0` jumps to level 10 (the last handcrafted puzzle, which is also the boundary where the procedural generator takes over). The jump clears the current selection and scraps any pending animation / demo queue so the transition is immediate and clean.
- Added the new legend line (`HudStrings.HelpLevels`) to all seven locales; it joins the top help row alongside Tab/Enter so players discover it when help is visible.

Closes #25

## Test plan
- [x] `Digit_keys_jump_to_the_matching_level` (theory over 1/2/5/9/0) — asserts `LevelIndex` after each press.
- [x] `Digit_jump_replaces_the_current_board_and_clears_selection` — asserts the selection is dropped and the board object changes.
- [x] Full quality gate passes (281/281).