### PR TITLE
test(docker): containerized linux-x64/linux-arm64 test environments

### DIFF
--- a/test-environments/.gitignore
+++ b/test-environments/.gitignore
@@ -1,0 +1,2 @@
+# Downloaded binaries — repopulated by fetch-release.sh / fetch-ci-artifacts.sh
+bin/

--- a/test-environments/README.md
+++ b/test-environments/README.md
@@ -1,0 +1,98 @@
+# Containerized test environments
+
+Disposable Docker images for kicking the tires on the published Linux Native-AoT
+binaries without polluting a host system. Geared at running on an Apple Silicon
+Mac via Docker Desktop:
+
+- `linux-arm64` runs natively
+- `linux-x64`   runs through Rosetta / QEMU emulation
+
+Each image is a tiny Ubuntu 24.04 with the bare runtime libs the AoT binary
+needs, plus the `terminal-snake` binary on `PATH`. The container's default
+command is `bash`, so you log in, run `terminal-snake`, exit with Ctrl+D.
+
+## Layout
+
+```
+test-environments/
+├── README.md
+├── fetch-release.sh         # download archives from a GitHub release
+├── fetch-ci-artifacts.sh    # download archives from a workflow run (needs gh)
+├── run.sh                   # docker build + interactive run
+├── linux-x64/Dockerfile
+├── linux-arm64/Dockerfile
+└── bin/                     # populated by the fetch scripts (gitignored)
+    ├── linux-x64/
+    └── linux-arm64/
+```
+
+## Quick start
+
+```bash
+cd test-environments
+
+# 1. Pull the latest release archives into bin/<rid>/
+./fetch-release.sh
+
+# 2. Build the image and drop into a shell
+./run.sh arm64        # or: ./run.sh x64
+
+# 3. Inside the container
+terminal-snake
+```
+
+## Fetching binaries
+
+### From a GitHub release (default)
+
+```bash
+./fetch-release.sh                # latest published release
+./fetch-release.sh v0.3.1         # specific tag
+GH_TOKEN=ghp_xxx ./fetch-release.sh   # avoid anonymous rate limits
+```
+
+### From a CI workflow run
+
+The `Release Artifacts` workflow uploads the same archives as workflow
+artifacts on dry-run pushes to `feature/release`. Useful for testing a build
+before tagging a release.
+
+```bash
+./fetch-ci-artifacts.sh           # latest successful run
+./fetch-ci-artifacts.sh 1234567   # specific run id
+```
+
+Requires the [`gh` CLI](https://cli.github.com), authenticated with
+`gh auth login` (artifacts are not anonymously downloadable).
+
+## Running
+
+```bash
+./run.sh                # defaults to arm64
+./run.sh x64            # linux/amd64 (Rosetta on Apple Silicon)
+./run.sh arm64 --build  # force rebuild without cache
+./run.sh x64 -- terminal-snake   # run the app directly instead of bash
+```
+
+The script mirrors the architecture you asked for to both `docker build
+--platform` and `docker run --platform`, and uses `--rm -it` so the
+container is gone on exit.
+
+Inside the container:
+
+- `terminal-snake` is on `PATH`
+- `TERM=xterm-256color`, `LANG=C.UTF-8` are pre-set
+- Working directory is `/opt/terminal-snake`
+
+Mouse input (SGR-1006) and 256-color rendering work out of the box from
+iTerm2, macOS Terminal, and most modern terminals — Docker just forwards the
+host TTY.
+
+## Notes
+
+- `bin/` is gitignored — re-fetch any time you want fresh binaries.
+- The Dockerfiles `COPY` from `bin/<rid>/` at build time, so each
+  `./run.sh` rebuild picks up whatever is currently staged there.
+- If a release pre-dates the `linux-arm64` / `linux-x64` archives or uses a
+  different naming scheme, override the binary by manually placing
+  `terminal-snake` (and any companion files) into `bin/<rid>/`.

--- a/test-environments/fetch-ci-artifacts.sh
+++ b/test-environments/fetch-ci-artifacts.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Download workflow artifacts (linux-x64 / linux-arm64 archives) from the most
+# recent successful 'Release Artifacts' run, or a specific run id.
+#
+# Requires the GitHub CLI (`gh`) for authenticated artifact download.
+#
+# Usage:
+#   ./fetch-ci-artifacts.sh                # latest successful run
+#   ./fetch-ci-artifacts.sh 1234567890     # specific run id
+#   ./fetch-ci-artifacts.sh -- linux-x64   # only one RID
+#
+# Env:
+#   REPO      override (default: gingters/terminal.snake)
+#   WORKFLOW  workflow name (default: 'Release Artifacts')
+
+set -euo pipefail
+
+REPO="${REPO:-gingters/terminal.snake}"
+WORKFLOW="${WORKFLOW:-Release Artifacts}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$SCRIPT_DIR"
+
+if ! command -v gh >/dev/null 2>&1; then
+    echo "ERROR: GitHub CLI 'gh' not found. Install: https://cli.github.com" >&2
+    exit 1
+fi
+
+RUN_ID=""
+RIDS=()
+while (( $# )); do
+    case "$1" in
+        --) shift; RIDS+=("$@"); break ;;
+        -h|--help) sed -n '2,13p' "$0"; exit 0 ;;
+        *) RUN_ID="$1" ;;
+    esac
+    shift
+done
+[[ ${#RIDS[@]} -eq 0 ]] && RIDS=(linux-x64 linux-arm64)
+
+if [[ -z "$RUN_ID" ]]; then
+    echo "Looking up latest successful '$WORKFLOW' run on $REPO..."
+    RUN_ID=$(gh run list \
+        --repo "$REPO" \
+        --workflow "$WORKFLOW" \
+        --limit 30 \
+        --json databaseId,status,conclusion \
+        --jq 'map(select(.status == "completed" and .conclusion == "success")) | .[0].databaseId')
+fi
+
+if [[ -z "$RUN_ID" || "$RUN_ID" == "null" ]]; then
+    echo "ERROR: could not find a successful '$WORKFLOW' run" >&2
+    exit 1
+fi
+
+echo "Using workflow run: $RUN_ID"
+
+for rid in "${RIDS[@]}"; do
+    artifact="terminal-snake-${rid}"
+    echo "==> $rid (artifact: $artifact)"
+
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    if ! gh run download "$RUN_ID" \
+            --repo "$REPO" \
+            --name "$artifact" \
+            --dir "$tmp"; then
+        echo "ERROR: failed to download artifact $artifact" >&2
+        exit 1
+    fi
+
+    archive="$(find "$tmp" -maxdepth 2 -name 'terminal-snake-*-'"$rid"'.tar.gz' -print -quit)"
+    if [[ -z "$archive" ]]; then
+        echo "ERROR: no .tar.gz archive found in artifact $artifact" >&2
+        exit 1
+    fi
+
+    rm -rf "bin/$rid"
+    mkdir -p "bin/$rid"
+    tar -xzf "$archive" -C "bin/$rid"
+    rm -rf "$tmp"
+    trap - EXIT
+
+    if [[ ! -x "bin/$rid/terminal-snake" ]]; then
+        chmod +x "bin/$rid/terminal-snake" 2>/dev/null || true
+    fi
+    echo "    -> bin/$rid/"
+done
+
+echo "Done. Build with: ./run.sh <x64|arm64>"

--- a/test-environments/fetch-release.sh
+++ b/test-environments/fetch-release.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Download the linux-x64 / linux-arm64 release archives for terminal-snake
+# and stage them under bin/<rid>/ so the Dockerfiles can COPY them in.
+#
+# Usage:
+#   ./fetch-release.sh              # latest published release
+#   ./fetch-release.sh v0.3.1       # specific tag
+#   ./fetch-release.sh -- linux-x64 # only one RID (after --)
+#
+# Env:
+#   REPO     override (default: gingters/terminal.snake)
+#   GH_TOKEN optional GitHub token for private/rate-limited access
+
+set -euo pipefail
+
+REPO="${REPO:-gingters/terminal.snake}"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$SCRIPT_DIR"
+
+TAG=""
+RIDS=()
+while (( $# )); do
+    case "$1" in
+        --) shift; RIDS+=("$@"); break ;;
+        -h|--help) sed -n '2,12p' "$0"; exit 0 ;;
+        *) TAG="$1" ;;
+    esac
+    shift
+done
+[[ ${#RIDS[@]} -eq 0 ]] && RIDS=(linux-x64 linux-arm64)
+
+auth_header=()
+if [[ -n "${GH_TOKEN:-}" ]]; then
+    auth_header=(-H "Authorization: Bearer $GH_TOKEN")
+fi
+
+if [[ -z "$TAG" || "$TAG" == "latest" ]]; then
+    echo "Resolving latest release for $REPO..."
+    TAG=$(curl -fsSL "${auth_header[@]}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/$REPO/releases/latest" \
+        | grep -o '"tag_name":[[:space:]]*"[^"]*"' \
+        | head -n1 \
+        | sed 's/.*"\([^"]*\)"$/\1/')
+fi
+
+if [[ -z "$TAG" ]]; then
+    echo "ERROR: could not determine release tag" >&2
+    exit 1
+fi
+
+echo "Using release: $TAG"
+
+for rid in "${RIDS[@]}"; do
+    archive="terminal-snake-${TAG}-${rid}.tar.gz"
+    url="https://github.com/$REPO/releases/download/${TAG}/${archive}"
+    echo "==> $rid"
+    echo "    $url"
+
+    tmp="$(mktemp -d)"
+    trap 'rm -rf "$tmp"' EXIT
+
+    if ! curl -fL --retry 3 --retry-delay 2 "${auth_header[@]}" \
+            -o "$tmp/$archive" "$url"; then
+        echo "ERROR: download failed for $rid" >&2
+        exit 1
+    fi
+
+    rm -rf "bin/$rid"
+    mkdir -p "bin/$rid"
+    tar -xzf "$tmp/$archive" -C "bin/$rid"
+    rm -rf "$tmp"
+    trap - EXIT
+
+    if [[ ! -x "bin/$rid/terminal-snake" ]]; then
+        chmod +x "bin/$rid/terminal-snake" 2>/dev/null || true
+    fi
+    echo "    -> bin/$rid/"
+done
+
+echo "Done. Build with: ./run.sh <x64|arm64>"

--- a/test-environments/linux-arm64/Dockerfile
+++ b/test-environments/linux-arm64/Dockerfile
@@ -1,0 +1,30 @@
+# Linux arm64 test environment for terminal-snake.
+# Targets linux/arm64 so it runs natively on Apple Silicon.
+
+FROM --platform=linux/arm64 ubuntu:24.04
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libstdc++6 \
+        zlib1g \
+        libssl3t64 \
+        libkrb5-3 \
+        ncurses-term \
+        bash \
+        less \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV TERM=xterm-256color \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH=/opt/terminal-snake:${PATH}
+
+WORKDIR /opt/terminal-snake
+
+# Populated by the host before `docker build` (see ../fetch-release.sh).
+COPY bin/linux-arm64/ /opt/terminal-snake/
+
+RUN chmod +x /opt/terminal-snake/terminal-snake
+
+CMD ["/bin/bash"]

--- a/test-environments/linux-arm64/Dockerfile
+++ b/test-environments/linux-arm64/Dockerfile
@@ -1,7 +1,11 @@
 # Linux arm64 test environment for terminal-snake.
 # Targets linux/arm64 so it runs natively on Apple Silicon.
 
-FROM --platform=linux/arm64 ubuntu:24.04
+# A custom ARG (not buildx's auto-populated TARGETPLATFORM) lets us pin
+# the architecture identically to the previous literal --platform value
+# while satisfying BuildKit's FromPlatformFlagConstDisallowed lint.
+ARG IMAGE_PLATFORM=linux/arm64
+FROM --platform=${IMAGE_PLATFORM} ubuntu:24.04
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/test-environments/linux-x64/Dockerfile
+++ b/test-environments/linux-x64/Dockerfile
@@ -2,7 +2,11 @@
 # Builds an image targeting linux/amd64 so it can be run on an Apple Silicon
 # Mac via Rosetta / QEMU emulation under Docker Desktop.
 
-FROM --platform=linux/amd64 ubuntu:24.04
+# A custom ARG (not buildx's auto-populated TARGETPLATFORM) lets us pin
+# the architecture identically to the previous literal --platform value
+# while satisfying BuildKit's FromPlatformFlagConstDisallowed lint.
+ARG IMAGE_PLATFORM=linux/amd64
+FROM --platform=${IMAGE_PLATFORM} ubuntu:24.04
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \

--- a/test-environments/linux-x64/Dockerfile
+++ b/test-environments/linux-x64/Dockerfile
@@ -1,0 +1,31 @@
+# Linux x64 test environment for terminal-snake.
+# Builds an image targeting linux/amd64 so it can be run on an Apple Silicon
+# Mac via Rosetta / QEMU emulation under Docker Desktop.
+
+FROM --platform=linux/amd64 ubuntu:24.04
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libstdc++6 \
+        zlib1g \
+        libssl3t64 \
+        libkrb5-3 \
+        ncurses-term \
+        bash \
+        less \
+ && rm -rf /var/lib/apt/lists/*
+
+ENV TERM=xterm-256color \
+    LANG=C.UTF-8 \
+    LC_ALL=C.UTF-8 \
+    PATH=/opt/terminal-snake:${PATH}
+
+WORKDIR /opt/terminal-snake
+
+# Populated by the host before `docker build` (see ../fetch-release.sh).
+COPY bin/linux-x64/ /opt/terminal-snake/
+
+RUN chmod +x /opt/terminal-snake/terminal-snake
+
+CMD ["/bin/bash"]

--- a/test-environments/run.sh
+++ b/test-environments/run.sh
@@ -51,8 +51,12 @@ fi
 
 IMAGE="terminal-snake-test:$RID"
 echo "Building $IMAGE for $PLATFORM..."
+# Bash 3 (the macOS default) treats `"${array[@]}"` on an empty array as
+# "unbound" under `set -u`. The `${array[@]+...}` guard only expands the
+# array when it is set, sidestepping the quirk without losing word
+# boundaries inside.
 docker build \
-    "${BUILD_ARGS[@]}" \
+    ${BUILD_ARGS[@]+"${BUILD_ARGS[@]}"} \
     --platform "$PLATFORM" \
     -f "$RID/Dockerfile" \
     -t "$IMAGE" \
@@ -63,4 +67,4 @@ exec docker run \
     --rm -it \
     --platform "$PLATFORM" \
     "$IMAGE" \
-    "${CMD[@]}"
+    ${CMD[@]+"${CMD[@]}"}

--- a/test-environments/run.sh
+++ b/test-environments/run.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build the test image for the chosen RID (using whatever sits in bin/<rid>/)
+# and drop into an interactive shell. Type `terminal-snake` to launch the app.
+#
+# Usage:
+#   ./run.sh                # defaults to arm64 (native on Apple Silicon)
+#   ./run.sh x64            # linux/amd64 (Rosetta/QEMU on Apple Silicon)
+#   ./run.sh arm64
+#   ./run.sh x64 --build    # force rebuild (no cache)
+#   ./run.sh x64 -- terminal-snake   # run a command instead of bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+cd "$SCRIPT_DIR"
+
+ARCH="${1:-arm64}"; shift || true
+
+case "$ARCH" in
+    x64|amd64|linux-x64)        RID=linux-x64;  PLATFORM=linux/amd64 ;;
+    arm64|aarch64|linux-arm64)  RID=linux-arm64; PLATFORM=linux/arm64 ;;
+    -h|--help)
+        sed -n '2,11p' "$0"; exit 0 ;;
+    *)
+        echo "Unknown arch: $ARCH (expected x64|arm64)" >&2
+        exit 1
+        ;;
+esac
+
+BUILD_ARGS=()
+CMD=()
+while (( $# )); do
+    case "$1" in
+        --build|--no-cache) BUILD_ARGS+=(--no-cache) ;;
+        --) shift; CMD=("$@"); break ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+    shift
+done
+
+if [[ ! -f "bin/$RID/terminal-snake" ]]; then
+    cat >&2 <<EOF
+No binary found at bin/$RID/terminal-snake.
+
+Fetch one first:
+  ./fetch-release.sh           # latest published release
+  ./fetch-ci-artifacts.sh      # latest successful CI run (needs gh CLI)
+EOF
+    exit 1
+fi
+
+IMAGE="terminal-snake-test:$RID"
+echo "Building $IMAGE for $PLATFORM..."
+docker build \
+    "${BUILD_ARGS[@]}" \
+    --platform "$PLATFORM" \
+    -f "$RID/Dockerfile" \
+    -t "$IMAGE" \
+    .
+
+echo "Starting container ($IMAGE). Run 'terminal-snake' inside, exit with Ctrl+D."
+exec docker run \
+    --rm -it \
+    --platform "$PLATFORM" \
+    "$IMAGE" \
+    "${CMD[@]}"


### PR DESCRIPTION
## Summary

Adds a `test-environments/` tree for smoke-testing the published Linux Native-AoT binaries inside disposable Docker containers — geared at running on an Apple Silicon Mac (arm64 native, amd64 via Rosetta).

```
test-environments/
├── README.md
├── fetch-release.sh          # download archives from a GitHub release
├── fetch-ci-artifacts.sh     # download archives from a workflow run (needs gh)
├── run.sh                    # docker build + interactive run
├── linux-x64/Dockerfile
├── linux-arm64/Dockerfile
└── bin/                      # populated by fetch scripts (gitignored)
```

### What it does

- **Two Dockerfiles** (`linux-x64`, `linux-arm64`), Ubuntu 24.04 base with the AoT runtime libs (`libstdc++6`, `zlib1g`, `libssl3t64`, `libkrb5-3`, `ncurses-term`). Each pins `--platform=linux/<arch>`. Default command is `bash`, with `terminal-snake` on `PATH`.
- **`fetch-release.sh`** resolves the latest release tag (or a tag you pass) via the GitHub API and downloads `terminal-snake-<tag>-<rid>.tar.gz` for both RIDs, extracting them into `bin/<rid>/`. No auth required for public releases; honors `GH_TOKEN` if set.
- **`fetch-ci-artifacts.sh`** pulls the same archives from the latest successful `Release Artifacts` workflow run (or a specific run id) via the `gh` CLI — handy for testing a build before tagging.
- **`run.sh <x64|arm64>`** rebuilds the image for the chosen RID (always picks up whatever is currently in `bin/<rid>/`) and execs into an interactive container with `--platform` mirrored on both build and run.
- **`bin/` is gitignored** — re-fetch any time.

### Typical flow

```bash
cd test-environments
./fetch-release.sh        # or ./fetch-ci-artifacts.sh
./run.sh arm64            # or x64
# inside the container:
terminal-snake
```

## Test plan

- [ ] `./fetch-release.sh` downloads and extracts both archives into `bin/linux-x64/` and `bin/linux-arm64/`
- [ ] `./run.sh arm64` builds the arm64 image and lands in bash with `terminal-snake` on PATH
- [ ] `terminal-snake` runs inside the arm64 container, mouse + 256-color render correctly
- [ ] `./run.sh x64` builds the amd64 image under Rosetta/QEMU and runs the binary
- [ ] `./fetch-ci-artifacts.sh` pulls artifacts from the latest successful `Release Artifacts` run with a logged-in `gh`


---
_Generated by [Claude Code](https://claude.ai/code/session_01M3SFXwoRQvphrMf2dYm144)_