### PR TITLE
fix(input): enable raw + VT mode on Windows console and pin UTF-8 output

### DIFF
--- a/src/TerminalSnake.App/Input/TerminalMode.cs
+++ b/src/TerminalSnake.App/Input/TerminalMode.cs
@@ -28,6 +28,7 @@ public sealed class TerminalMode : IDisposable
     {
         ArgumentNullException.ThrowIfNull(output);
         PosixTerminal.EnterRawMode();
+        WindowsTerminal.EnterRawMode();
         output.Write(TerminalEscapeSequences.EnableMouse);
         output.Write(TerminalEscapeSequences.HideCursor);
         output.Flush();
@@ -44,6 +45,7 @@ public sealed class TerminalMode : IDisposable
         output.Write(TerminalEscapeSequences.ShowCursor);
         output.Write(TerminalEscapeSequences.DisableMouse);
         output.Flush();
+        WindowsTerminal.Restore();
         PosixTerminal.Restore();
         _enabled = false;
     }

--- a/src/TerminalSnake.App/Input/WindowsTerminal.cs
+++ b/src/TerminalSnake.App/Input/WindowsTerminal.cs
@@ -1,0 +1,106 @@
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.InteropServices;
+
+namespace TerminalSnake.Input;
+
+// Direct P/Invoke wrapper around the Win32 console mode API. Without
+// this, stdin on Windows stays in cooked mode (ENABLE_LINE_INPUT +
+// ENABLE_ECHO_INPUT) so ReadFile blocks until Enter and the engine
+// never sees Tab, Enter, Q, arrow keys, or mouse events. We also flip
+// stdout into VT processing mode so the ANSI escape sequences Spectre
+// and TerminalEscapeSequences emit (cursor hide, mouse enable, screen
+// clear) reach the terminal as control sequences instead of literal
+// characters.
+//
+// Only Windows is implemented here; non-Windows callers are no-ops.
+[ExcludeFromCodeCoverage]
+internal static partial class WindowsTerminal
+{
+    private const int StdInputHandle = -10;
+    private const int StdOutputHandle = -11;
+
+    private const uint EnableProcessedInput = 0x0001;
+    private const uint EnableLineInput = 0x0002;
+    private const uint EnableEchoInput = 0x0004;
+    private const uint EnableMouseInput = 0x0010;
+    private const uint EnableQuickEditMode = 0x0040;
+    private const uint EnableExtendedFlags = 0x0080;
+    private const uint EnableVirtualTerminalInput = 0x0200;
+
+    private const uint EnableVirtualTerminalProcessing = 0x0004;
+    private const uint DisableNewlineAutoReturn = 0x0008;
+
+    private static readonly IntPtr InvalidHandle = new(-1);
+
+    private static bool _hasSaved;
+    private static uint _savedInputMode;
+    private static uint _savedOutputMode;
+    private static IntPtr _stdin;
+    private static IntPtr _stdout;
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    private static partial IntPtr GetStdHandle(int nStdHandle);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool GetConsoleMode(IntPtr hConsoleHandle, out uint lpMode);
+
+    [LibraryImport("kernel32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static partial bool SetConsoleMode(IntPtr hConsoleHandle, uint dwMode);
+
+    public static bool EnterRawMode()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            return false;
+        }
+
+        _stdin = GetStdHandle(StdInputHandle);
+        _stdout = GetStdHandle(StdOutputHandle);
+        if (_stdin == IntPtr.Zero || _stdin == InvalidHandle ||
+            _stdout == IntPtr.Zero || _stdout == InvalidHandle)
+        {
+            return false;
+        }
+
+        if (!GetConsoleMode(_stdin, out _savedInputMode) ||
+            !GetConsoleMode(_stdout, out _savedOutputMode))
+        {
+            return false;
+        }
+        _hasSaved = true;
+
+        // Strip line discipline + echo so single keystrokes deliver
+        // immediately, kill QuickEdit so left-clicks no longer get
+        // intercepted as text-selection, and add VT input + mouse so
+        // SGR-1006 mouse reports and ESC[A-style arrow sequences reach
+        // the byte stream. ENABLE_PROCESSED_INPUT stays on so Ctrl+C
+        // still routes through the .NET CancelKeyPress handler.
+        var input = (_savedInputMode
+                     & ~EnableLineInput
+                     & ~EnableEchoInput
+                     & ~EnableQuickEditMode)
+                    | EnableExtendedFlags
+                    | EnableMouseInput
+                    | EnableVirtualTerminalInput
+                    | EnableProcessedInput;
+
+        var output = _savedOutputMode
+                     | EnableVirtualTerminalProcessing
+                     | DisableNewlineAutoReturn;
+
+        return SetConsoleMode(_stdin, input) && SetConsoleMode(_stdout, output);
+    }
+
+    public static void Restore()
+    {
+        if (!OperatingSystem.IsWindows() || !_hasSaved)
+        {
+            return;
+        }
+        SetConsoleMode(_stdin, _savedInputMode);
+        SetConsoleMode(_stdout, _savedOutputMode);
+        _hasSaved = false;
+    }
+}

--- a/src/TerminalSnake.App/Program.cs
+++ b/src/TerminalSnake.App/Program.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Text;
 using System.Threading.Channels;
 using Spectre.Console;
 using TerminalSnake.Game;
@@ -18,6 +19,12 @@ internal static class Program
 {
     private static int Main(string[] args)
     {
+        // Pin the console to UTF-8 before any write so the box-drawing
+        // glyphs (═ ║ ╔ ╗ ╚ ╝ ► ◄ ▲ ▼) survive the journey. Without
+        // this, Windows console hosts default to the OEM code page
+        // (CP437/CP850 depending on locale) and our multi-byte UTF-8
+        // sequences land as garbage that shifts subsequent columns.
+        Console.OutputEncoding = Encoding.UTF8;
         try
         {
             return Run();


### PR DESCRIPTION
The Windows AoT build inherited the default console mode, which has ENABLE_LINE_INPUT and ENABLE_ECHO_INPUT on. ReadFile on stdin therefore blocked until Enter, and arrow/Tab/Enter never produced VT byte sequences — all input appeared dead while only Ctrl+C terminated the process via the OS-level signal path.

WindowsTerminal mirrors PosixTerminal: it captures the saved input and output console modes via GetConsoleMode, strips line discipline, echo, and QuickEdit, layers in ENABLE_VIRTUAL_TERMINAL_INPUT plus mouse + extended flags so SGR-1006 mouse reports and ESC[A-style arrow keys flow through, and flips ENABLE_VIRTUAL_TERMINAL_PROCESSING on stdout so our ANSI sequences are honored. Restore() rewinds both modes on shutdown via TerminalMode.Disable.

Pinning Console.OutputEncoding to UTF-8 in Main fixes the misaligned frame: the renderer emits multi-byte UTF-8 sequences for box-drawing chars, but a console host on the OEM code page treats those as three separate single-byte glyphs and shifts every subsequent column.