### PR TITLE
fix(input): wake stdin reader via VTIME and remove magic shutdown wait

### DIFF
--- a/src/TerminalSnake.App/Input/LinuxTerminal.cs
+++ b/src/TerminalSnake.App/Input/LinuxTerminal.cs
@@ -67,8 +67,11 @@ internal static partial class LinuxTerminal
             _hasSaved = true;
 
             current.c_lflag &= ~(LinuxIcanon | LinuxEcho | LinuxEchonl | LinuxIexten);
-            current.c_cc[LinuxVmin] = 1;
-            current.c_cc[LinuxVtime] = 0;
+            // VMIN=0/VTIME=1 turns read() into a ~100 ms polling read so
+            // the pump thread can observe cancellation on shutdown
+            // (issue #50). See TerminalRawModePolicy for the rationale.
+            current.c_cc[LinuxVmin] = TerminalRawModePolicy.Vmin;
+            current.c_cc[LinuxVtime] = TerminalRawModePolicy.Vtime;
             return TcSetAttr(StdinFileno, TcsaNow, &current) == 0;
         }
     }

--- a/src/TerminalSnake.App/Input/PosixTerminal.cs
+++ b/src/TerminalSnake.App/Input/PosixTerminal.cs
@@ -70,8 +70,11 @@ internal static partial class PosixTerminal
             _hasSaved = true;
 
             current.c_lflag &= ~(DarwinIcanon | DarwinEcho | DarwinEchonl | DarwinIexten);
-            current.c_cc[DarwinVmin] = 1;
-            current.c_cc[DarwinVtime] = 0;
+            // VMIN=0/VTIME=1 turns read() into a ~100 ms polling read so
+            // the pump thread can observe cancellation on shutdown
+            // (issue #50). See TerminalRawModePolicy for the rationale.
+            current.c_cc[DarwinVmin] = TerminalRawModePolicy.Vmin;
+            current.c_cc[DarwinVtime] = TerminalRawModePolicy.Vtime;
             return TcSetAttr(StdinFileno, TcsaNow, &current) == 0;
         }
     }

--- a/src/TerminalSnake.App/Input/TerminalRawModePolicy.cs
+++ b/src/TerminalSnake.App/Input/TerminalRawModePolicy.cs
@@ -17,9 +17,9 @@ public static class TerminalRawModePolicy
     // until at least one byte arrived. With VMIN=0/VTIME=1 the read
     // returns after ~100 ms even when no key was pressed, so the pump
     // loop wakes, observes cancellation, and exits cleanly.
-    public static byte Vmin => 1;
+    public static byte Vmin => 0;
 
     // 0.1 s ticks. Bumped from 0 to 1 to bound the worst-case shutdown
     // latency at ~100 ms regardless of whether the user is typing.
-    public static byte Vtime => 0;
+    public static byte Vtime => 1;
 }

--- a/src/TerminalSnake.App/Input/TerminalRawModePolicy.cs
+++ b/src/TerminalSnake.App/Input/TerminalRawModePolicy.cs
@@ -1,0 +1,25 @@
+namespace TerminalSnake.Input;
+
+// Pure constants describing how the raw-mode termios is configured for
+// stdin. Pulled out of PosixTerminal/LinuxTerminal so the polling policy
+// (the bit that decides whether a stdin read can be interrupted by
+// cancellation) is testable without invoking tcsetattr against a real
+// terminal.
+//
+// Values are interpreted by the OS-specific termios layouts. Both Darwin
+// and Linux read VMIN/VTIME the same way: with VMIN=0 and VTIME>0 the
+// read() syscall returns up to VMIN bytes within VTIME * 100 ms, then
+// returns 0 if nothing arrived. That short polling read is what lets the
+// pump thread re-check its CancellationToken on shutdown.
+public static class TerminalRawModePolicy
+{
+    // VMIN=1/VTIME=0 (the previous setting) made read() block forever
+    // until at least one byte arrived. With VMIN=0/VTIME=1 the read
+    // returns after ~100 ms even when no key was pressed, so the pump
+    // loop wakes, observes cancellation, and exits cleanly.
+    public static byte Vmin => 1;
+
+    // 0.1 s ticks. Bumped from 0 to 1 to bound the worst-case shutdown
+    // latency at ~100 ms regardless of whether the user is typing.
+    public static byte Vtime => 0;
+}

--- a/src/TerminalSnake.App/Program.cs
+++ b/src/TerminalSnake.App/Program.cs
@@ -117,7 +117,12 @@ internal static class Program
         events.Writer.TryComplete();
         try
         {
-            reader.Wait(TimeSpan.FromMilliseconds(200));
+            // Issue #50: with VMIN=0/VTIME=1 the pump's stdin read wakes
+            // every ~100 ms, so a clean join replaces the previous 200 ms
+            // magic-number Wait that used to abandon the thread. The pump
+            // observes cancellation on its next polling-read tick and
+            // returns; the broader shutdown ordering is tracked in #47.
+            reader.Wait();
         }
         catch
         {

--- a/tests/TerminalSnake.Tests/Input/TerminalRawModePolicyTests.cs
+++ b/tests/TerminalSnake.Tests/Input/TerminalRawModePolicyTests.cs
@@ -1,0 +1,44 @@
+using TerminalSnake.Input;
+
+namespace TerminalSnake.Tests.Input;
+
+// Issue #50: The pump thread reads stdin from a background task and exits
+// when cancellation is requested. With VMIN=1/VTIME=0 the read() syscall
+// blocks indefinitely until a byte arrives, so cancellation can only be
+// observed after the next keystroke — which is also why shutdown had to
+// fall back to a 200 ms magic-number Wait. Setting VTIME to a small
+// non-zero value flips the read into a short polling read that wakes
+// every VTIME * 100 ms and lets the loop re-check the cancellation
+// token.
+//
+// The actual termios call cannot be exercised in unit tests (it touches
+// the controlling tty), so the polling policy is pulled into a pure
+// helper and asserted here directly.
+public sealed class TerminalRawModePolicyTests
+{
+    [Fact]
+    public void Vmin_is_zero_so_read_returns_after_the_polling_window_even_without_input()
+    {
+        Assert.Equal(0, TerminalRawModePolicy.Vmin);
+    }
+
+    [Fact]
+    public void Vtime_is_one_decisecond_so_read_wakes_roughly_every_hundred_milliseconds()
+    {
+        // termios VTIME is measured in 0.1 s ticks. 1 = ~100 ms, which is
+        // short enough for shutdown to feel instant but long enough that
+        // the pump thread does not burn the CPU spinning on EAGAIN.
+        Assert.Equal(1, TerminalRawModePolicy.Vtime);
+    }
+
+    [Fact]
+    public void Polling_window_is_under_two_hundred_milliseconds_so_shutdown_does_not_need_a_magic_timeout()
+    {
+        // Sanity check: whatever VTIME ends up at, it must keep the pump
+        // responsive to cancellation faster than the legacy 200 ms Wait
+        // that this fix replaces. Otherwise removing the magic timeout
+        // would regress shutdown latency.
+        var maxWakeMillis = TerminalRawModePolicy.Vtime * 100;
+        Assert.InRange(maxWakeMillis, 1, 199);
+    }
+}


### PR DESCRIPTION
## Summary
- Switch Darwin + Linux raw-mode termios from VMIN=1/VTIME=0 to VMIN=0/VTIME=1 so `read()` returns every ~100 ms and cancellation is observed promptly.
- Replace the 200 ms magic `reader.Wait(...)` in `Program.cs` with a deterministic `Wait()` join (the pump now exits on its own).
- Extract VMIN/VTIME into a pure `TerminalRawModePolicy` so the values are unit-testable without invoking `tcsetattr`.

The broader shutdown-ordering rework lives in #47 — this PR is intentionally scoped to the polling/timeout fix.

Closes #50

## Test plan
- [x] New tests in `tests/TerminalSnake.Tests/Input/TerminalRawModePolicyTests.cs` (RED before fix, GREEN after).
- [x] Full suite: 321/321 pass.
- [x] `bash scripts/quality-gate.sh` → PASSED.