### PR TITLE
feat(app): handle SIGTERM/SIGHUP/SIGQUIT to restore tty on shutdown

### DIFF
--- a/src/TerminalSnake.App/Input/ShutdownSignals.cs
+++ b/src/TerminalSnake.App/Input/ShutdownSignals.cs
@@ -1,0 +1,85 @@
+using System.Collections.Immutable;
+using System.Runtime.InteropServices;
+
+namespace TerminalSnake.Input;
+
+// #49 — Without these registrations only Ctrl+C runs Program.Run's finally
+// block. SIGTERM (`kill <pid>`), SIGHUP (terminal close), and SIGQuit
+// (Ctrl+\) bypass it and the tty stays in raw mode, forcing the user to
+// type `stty sane` blind. Hooking the same cancellation source the
+// Console.CancelKeyPress handler drives gives the existing shutdown path
+// a chance to restore the terminal on every recoverable signal.
+//
+// SIGKILL is intentionally omitted — the kernel does not deliver it to the
+// process so no handler can run.
+public static class ShutdownSignals
+{
+    /// <summary>
+    /// The set of POSIX signals that should drive the shared shutdown
+    /// path. Exposed so tests can pin the intended set without exercising
+    /// real signal delivery.
+    /// </summary>
+    public static ImmutableArray<PosixSignal> Signals { get; } = ImmutableArray.Create(
+        PosixSignal.SIGINT,
+        PosixSignal.SIGTERM,
+        PosixSignal.SIGHUP,
+        PosixSignal.SIGQUIT);
+
+    /// <summary>
+    /// Registers a handler for every signal in <see cref="Signals"/>.
+    /// Each handler cancels <paramref name="cts"/> and marks the signal
+    /// as handled so the runtime skips its default termination, giving
+    /// the cancellation token consumer time to tear down the terminal.
+    /// </summary>
+    /// <param name="cts">Cancellation source driven by the handlers.</param>
+    /// <param name="factory">
+    /// Factory that returns an <see cref="IDisposable"/> for a
+    /// (signal, handler) pair. Defaults to
+    /// <see cref="PosixSignalRegistration.Create"/> in production; tests
+    /// inject a fake to verify wiring without raising real signals.
+    /// </param>
+    public static IDisposable Register(
+        CancellationTokenSource cts,
+        Func<PosixSignal, Action<PosixSignalContext>, IDisposable>? factory = null)
+    {
+        ArgumentNullException.ThrowIfNull(cts);
+        var create = factory ?? DefaultFactory;
+        var registrations = new List<IDisposable>(Signals.Length);
+        foreach (var signal in Signals)
+        {
+            registrations.Add(create(signal, ctx =>
+            {
+                ctx.Cancel = true;
+                cts.Cancel();
+            }));
+        }
+        return new CompositeDisposable(registrations);
+    }
+
+    private static IDisposable DefaultFactory(PosixSignal signal, Action<PosixSignalContext> handler)
+        => PosixSignalRegistration.Create(signal, handler);
+
+    private sealed class CompositeDisposable : IDisposable
+    {
+        private readonly IReadOnlyList<IDisposable> _items;
+        private bool _disposed;
+
+        public CompositeDisposable(IReadOnlyList<IDisposable> items)
+        {
+            _items = items;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+            _disposed = true;
+            foreach (var item in _items)
+            {
+                item.Dispose();
+            }
+        }
+    }
+}

--- a/src/TerminalSnake.App/Program.cs
+++ b/src/TerminalSnake.App/Program.cs
@@ -76,6 +76,12 @@ internal static class Program
             e.Cancel = true;
             cts.Cancel();
         };
+        // #49 — Console.CancelKeyPress only catches Ctrl+C. SIGTERM (kill),
+        // SIGHUP (terminal close), and SIGQUIT (Ctrl+\) bypass the managed
+        // handler and skip Run's finally block, leaving the tty in raw mode.
+        // Driving the same cancellation source on every recoverable signal
+        // makes shutdown deterministic.
+        using var signalRegistration = ShutdownSignals.Register(cts);
 
         var events = Channel.CreateUnbounded<InputEvent>();
         var reader = Task.Run(() => PumpStdin(events.Writer, cts.Token));

--- a/tests/TerminalSnake.Tests/Input/ShutdownSignalsTests.cs
+++ b/tests/TerminalSnake.Tests/Input/ShutdownSignalsTests.cs
@@ -1,0 +1,122 @@
+using System.Runtime.InteropServices;
+using TerminalSnake.Input;
+
+namespace TerminalSnake.Tests.Input;
+
+// #49 — Without SIGTERM/SIGHUP/SIGQUIT registrations the finally block in
+// Program.Run never runs on `kill <pid>`, terminal close, or Ctrl+\, leaving
+// the tty in raw mode. These tests pin the intended signal set and the
+// cancellation wiring through a test-friendly seam.
+public sealed class ShutdownSignalsTests
+{
+    [Fact]
+    public void Signals_cover_sigint_sigterm_sighup_sigquit()
+    {
+        Assert.Contains(PosixSignal.SIGINT, ShutdownSignals.Signals);
+        Assert.Contains(PosixSignal.SIGTERM, ShutdownSignals.Signals);
+        Assert.Contains(PosixSignal.SIGHUP, ShutdownSignals.Signals);
+        Assert.Contains(PosixSignal.SIGQUIT, ShutdownSignals.Signals);
+    }
+
+    [Fact]
+    public void Register_subscribes_one_handler_per_intended_signal()
+    {
+        var fake = new FakeSignalRegistry();
+        using var cts = new CancellationTokenSource();
+
+        using var registration = ShutdownSignals.Register(cts, fake.Create);
+
+        Assert.Equal(ShutdownSignals.Signals.Length, fake.Subscriptions.Count);
+        foreach (var signal in ShutdownSignals.Signals)
+        {
+            Assert.Contains(signal, fake.Subscriptions.Select(s => s.Signal));
+        }
+    }
+
+    [Fact]
+    public void Triggering_any_registered_signal_cancels_the_token_source()
+    {
+        foreach (var signal in ShutdownSignals.Signals)
+        {
+            var fake = new FakeSignalRegistry();
+            using var cts = new CancellationTokenSource();
+            using var registration = ShutdownSignals.Register(cts, fake.Create);
+
+            var match = fake.Subscriptions.Single(s => s.Signal == signal);
+            match.Fire();
+
+            Assert.True(cts.IsCancellationRequested,
+                $"Expected {signal} handler to cancel the token source.");
+        }
+    }
+
+    [Fact]
+    public void Registered_handler_marks_signal_as_handled_so_runtime_skips_default_action()
+    {
+        // The whole point of intercepting these signals is to preempt the
+        // runtime's default termination — without Cancel = true the process
+        // dies before our finally block can restore the tty.
+        var fake = new FakeSignalRegistry();
+        using var cts = new CancellationTokenSource();
+        using var registration = ShutdownSignals.Register(cts, fake.Create);
+
+        foreach (var sub in fake.Subscriptions)
+        {
+            var ctx = sub.Fire();
+            Assert.True(ctx.Cancel,
+                $"Expected {sub.Signal} handler to set Cancel=true to suppress default.");
+        }
+    }
+
+    [Fact]
+    public void Disposing_register_result_disposes_every_underlying_registration()
+    {
+        var fake = new FakeSignalRegistry();
+        using var cts = new CancellationTokenSource();
+
+        var registration = ShutdownSignals.Register(cts, fake.Create);
+        registration.Dispose();
+
+        Assert.All(fake.Subscriptions, s => Assert.True(s.Disposed));
+    }
+
+    private sealed class FakeSignalRegistry
+    {
+        public List<FakeSubscription> Subscriptions { get; } = new();
+
+        public IDisposable Create(PosixSignal signal, Action<PosixSignalContext> handler)
+        {
+            var sub = new FakeSubscription(signal, handler);
+            Subscriptions.Add(sub);
+            return sub;
+        }
+    }
+
+    private sealed class FakeSubscription : IDisposable
+    {
+        private readonly Action<PosixSignalContext> _handler;
+
+        public FakeSubscription(PosixSignal signal, Action<PosixSignalContext> handler)
+        {
+            Signal = signal;
+            _handler = handler;
+        }
+
+        public PosixSignal Signal { get; }
+        public bool Disposed { get; private set; }
+
+        public PosixSignalContext Fire()
+        {
+            // PosixSignalContext has no public constructor; the runtime
+            // hands one to the handler. Allocate an uninitialised instance
+            // so the handler can flip Cancel — that is the only field the
+            // shutdown handler reads or writes.
+            var ctx = (PosixSignalContext)System.Runtime.CompilerServices
+                .RuntimeHelpers.GetUninitializedObject(typeof(PosixSignalContext));
+            _handler(ctx);
+            return ctx;
+        }
+
+        public void Dispose() => Disposed = true;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `ShutdownSignals.Register(...)` wiring SIGINT/SIGTERM/SIGHUP/SIGQUIT to the existing cancellation flow via `PosixSignalRegistration`, marking each handled to suppress default termination.
- `Program.RunLoop` disposes the registration in the same scope as `Console.CancelKeyPress`, so every recoverable signal drains through `TerminalMode.Disable` and restores the tty.
- Signal-registration factory is parameterised so tests can exercise the wiring without raising real signals.

Closes #49

## Test plan
- [x] New tests in `tests/TerminalSnake.Tests/Input/ShutdownSignalsTests.cs` cover the intended signal set, per-signal registration, cancellation, the handled flag, and disposal (RED before, GREEN after).
- [x] Full suite: 323/323 pass.
- [x] `bash scripts/quality-gate.sh` → PASSED.