### PR TITLE
fix(input): decode SGR-1006 wheel and modifier bits without left-click fallback

### DIFF
--- a/src/TerminalSnake.App/Input/InputDecoder.cs
+++ b/src/TerminalSnake.App/Input/InputDecoder.cs
@@ -165,29 +165,54 @@ public static class InputDecoder
 
     private static MouseClickEvent? BuildMouseEvent(string payload, bool isPress)
     {
-        if (!isPress)
+        if (!isPress || !TryParseSgrTriplet(payload, out var button, out var column, out var row))
         {
             return null;
         }
+        var mapped = MapButton(button);
+        return mapped is null ? null : new MouseClickEvent(column - 1, row - 1, mapped.Value);
+    }
+
+    private static bool TryParseSgrTriplet(string payload, out int button, out int column, out int row)
+    {
+        button = column = row = 0;
         var parts = payload.Split(';');
         if (parts.Length != 3)
         {
-            return null;
+            return false;
         }
-        if (!int.TryParse(parts[0], out var button) ||
-            !int.TryParse(parts[1], out var column) ||
-            !int.TryParse(parts[2], out var row))
+        return int.TryParse(parts[0], out button)
+            && int.TryParse(parts[1], out column)
+            && int.TryParse(parts[2], out row);
+    }
+
+    // SGR-1006 button code layout (xterm):
+    //   bits 0-1: button (0=Left, 1=Middle, 2=Right, 3=release-with-no-button)
+    //   bit  2 (4) : Shift modifier
+    //   bit  3 (8) : Meta/Alt modifier
+    //   bit  4 (16): Ctrl modifier
+    //   bit  5 (32): motion flag (sent while a button is held during drag)
+    //   bit  6 (64): wheel event (button=64 wheel-up, 65 wheel-down)
+    //   bit  7 (128): "extra" buttons 8-11
+    // We only surface plain button presses; motion, wheel, and extra
+    // buttons collapsing into Left clicks was issue #48.
+    private const int MotionFlag = 32;
+    private const int WheelFlag = 64;
+    private const int ExtraButtonFlag = 128;
+    private const int NonClickMask = MotionFlag | WheelFlag | ExtraButtonFlag;
+
+    private static MouseButton? MapButton(int raw)
+    {
+        if ((raw & NonClickMask) != 0)
         {
             return null;
         }
-        return new MouseClickEvent(column - 1, row - 1, MapButton(button));
+        return (raw & 0b11) switch
+        {
+            0 => MouseButton.Left,
+            1 => MouseButton.Middle,
+            2 => MouseButton.Right,
+            _ => null,
+        };
     }
-
-    private static MouseButton MapButton(int raw) => (raw & 0b11) switch
-    {
-        0 => MouseButton.Left,
-        1 => MouseButton.Middle,
-        2 => MouseButton.Right,
-        _ => MouseButton.Left,
-    };
 }

--- a/tests/TerminalSnake.Tests/Input/InputDecoderTests.cs
+++ b/tests/TerminalSnake.Tests/Input/InputDecoderTests.cs
@@ -136,6 +136,78 @@ public sealed class InputDecoderTests
     }
 
     [Theory]
+    [InlineData(8)]   // meta/alt + left
+    [InlineData(16)]  // ctrl + left
+    [InlineData(20)]  // shift + ctrl + left
+    public void Sgr_mouse_modifier_bits_decode_to_left_click(int button)
+    {
+        var buffer = Encoding.ASCII.GetBytes($"\x1b[<{button};5;5M");
+        InputDecoder.TryDecode(buffer, out var evt);
+        var click = Assert.IsType<MouseClickEvent>(evt);
+        Assert.Equal(MouseButton.Left, click.Button);
+    }
+
+    [Theory]
+    [InlineData(17)]  // ctrl + middle
+    [InlineData(18)]  // ctrl + right
+    [InlineData(6)]   // shift + right
+    public void Sgr_mouse_modifier_bits_do_not_corrupt_button(int button)
+    {
+        var buffer = Encoding.ASCII.GetBytes($"\x1b[<{button};5;5M");
+        InputDecoder.TryDecode(buffer, out var evt);
+        var click = Assert.IsType<MouseClickEvent>(evt);
+        var expected = (button & 0b11) switch
+        {
+            1 => MouseButton.Middle,
+            2 => MouseButton.Right,
+            _ => MouseButton.Left,
+        };
+        Assert.Equal(expected, click.Button);
+    }
+
+    [Theory]
+    [InlineData(64)]  // wheel up
+    [InlineData(65)]  // wheel down
+    [InlineData(66)]  // wheel left (rare)
+    [InlineData(67)]  // wheel right (rare)
+    [InlineData(68)]  // wheel + shift
+    [InlineData(80)]  // wheel + ctrl
+    public void Sgr_mouse_wheel_events_emit_no_click(int button)
+    {
+        var sequence = $"\x1b[<{button};5;5M";
+        var buffer = Encoding.ASCII.GetBytes(sequence);
+        var consumed = InputDecoder.TryDecode(buffer, out var evt);
+        Assert.Equal(buffer.Length, consumed);
+        Assert.Null(evt);
+    }
+
+    [Theory]
+    [InlineData(35)]  // motion no-button (32 | 3 = "no button" in xterm)
+    [InlineData(32)]  // motion + left
+    [InlineData(33)]  // motion + middle
+    [InlineData(34)]  // motion + right
+    public void Sgr_mouse_motion_events_emit_no_click(int button)
+    {
+        var sequence = $"\x1b[<{button};5;5M";
+        var buffer = Encoding.ASCII.GetBytes(sequence);
+        var consumed = InputDecoder.TryDecode(buffer, out var evt);
+        Assert.Equal(buffer.Length, consumed);
+        Assert.Null(evt);
+    }
+
+    [Theory]
+    [InlineData(128)] // extra button 8
+    [InlineData(129)] // extra button 9
+    public void Sgr_mouse_extra_buttons_emit_no_click(int button)
+    {
+        var sequence = $"\x1b[<{button};5;5M";
+        var buffer = Encoding.ASCII.GetBytes(sequence);
+        var consumed = InputDecoder.TryDecode(buffer, out var evt);
+        Assert.Equal(buffer.Length, consumed);
+        Assert.Null(evt);
+    }
+
+    [Theory]
     [InlineData('A', ConsoleKey.UpArrow)]
     [InlineData('B', ConsoleKey.DownArrow)]
     [InlineData('C', ConsoleKey.RightArrow)]


### PR DESCRIPTION
## Summary
- `MapButton` previously masked only the low 2 bits, so wheel events (64/65), motion reports (bit 5) and "extra" buttons (bit 7) collapsed to phantom Left clicks.
- Filter motion / wheel / extra-button reports out before the low-2-bit decode; unknown low-bit codes now return `null` instead of being silently coerced to Left.
- Modifier bits (Shift=4, Meta=8, Ctrl=16) don't overlap the button field, so they continue to be handled correctly — documented in code.
- Split SGR triplet parsing into a helper to keep `BuildMouseEvent` under the complexity gate.

Closes #48

## Test plan
- [x] New parameterised tests in `tests/TerminalSnake.Tests/Input/InputDecoderTests.cs` cover wheel (64/65/66/67/68/80), motion (32-35), extra buttons (128/129) and modifier combinations (Meta/Ctrl/Shift+Ctrl on Left/Middle/Right). 12/18 cases were RED before fix.
- [x] Full suite: 336/336 pass.
- [x] `bash scripts/quality-gate.sh` → PASSED.