### PR TITLE
fix(app): synchronize stdin pump exit before restoring terminal mode

### DIFF
--- a/src/TerminalSnake.App/Game/ShutdownSequence.cs
+++ b/src/TerminalSnake.App/Game/ShutdownSequence.cs
@@ -1,0 +1,75 @@
+namespace TerminalSnake.Game;
+
+// Orchestrates the four-step shutdown of the live game loop in a
+// deterministic order so the tty restore (`tcsetattr`) never races
+// the background stdin pump's blocking `Read`. Issue #47.
+//
+// Order is load-bearing:
+//   1. Cancel — flips the token so the pump's loop predicate fails
+//      on its next iteration.
+//   2. Join   — waits up to `pumpJoinTimeout` for the pump task to
+//      observe cancellation and return. A bounded wait, not an
+//      indefinite one, because under VTIME=0 the pump can be
+//      parked inside `read(2)` with no way to wake; we still owe
+//      the user a restored terminal in that case (see comment in
+//      `Run`).
+//   3. Disable — runs the terminal-restore action (xterm sequences
+//      + `tcsetattr`). This is the call that previously raced the
+//      pump and the whole reason for this seam.
+//
+// Kept as a static seam (not a class) because it owns no state — it
+// is purely an ordering policy. Pulled out of `Program.RunLoop` so
+// it can be unit-tested without a real terminal.
+public static class ShutdownSequence
+{
+    public static void Run(
+        CancellationTokenSource cancel,
+        Task pumpTask,
+        TimeSpan pumpJoinTimeout,
+        Action disable)
+    {
+        ArgumentNullException.ThrowIfNull(cancel);
+        ArgumentNullException.ThrowIfNull(pumpTask);
+        ArgumentNullException.ThrowIfNull(disable);
+
+        // Step 1 — signal the pump. Cancel BEFORE joining: otherwise
+        // the wait would deadlock (pump never wakes) for the full
+        // timeout on every shutdown.
+        try
+        {
+            cancel.Cancel();
+        }
+        catch (AggregateException)
+        {
+            // Token registrations may throw; we still need to keep
+            // walking through Disable. Swallow and continue.
+        }
+
+        // Step 2 — give the pump a deterministic chance to exit.
+        // `Task.Wait(timeout)` returns false on timeout (no throw),
+        // and rethrows AggregateException for a faulted task — which
+        // we eat: the pump catches its own IO failures, but if one
+        // somehow escapes, leaving the terminal in raw mode is worse
+        // than dropping the exception.
+        //
+        // Limitation: with VTIME=0 (current main as of #47) the pump
+        // can be parked inside a blocking `read(2)` and won't observe
+        // the cancellation token until bytes arrive. The bounded join
+        // ensures we still proceed to Disable; #50 raises VTIME so
+        // the read self-wakes and the join completes promptly. This
+        // sequence composes with either VTIME setting unchanged.
+        try
+        {
+            pumpTask.Wait(pumpJoinTimeout);
+        }
+        catch (AggregateException)
+        {
+            // Pump faulted — terminal restore still has to run.
+        }
+
+        // Step 3 — restore the terminal. Now safe: the pump has
+        // either exited or been declared a lost cause, so no
+        // concurrent `stdin.Read` can collide with `tcsetattr`.
+        disable();
+    }
+}

--- a/src/TerminalSnake.App/Program.cs
+++ b/src/TerminalSnake.App/Program.cs
@@ -57,18 +57,18 @@ internal static class Program
 
         using var terminalMode = new TerminalMode();
         terminalMode.Enable(Console.Out);
-        try
-        {
-            RunLoop(engine);
-        }
-        finally
-        {
-            terminalMode.Disable(Console.Out);
-        }
+        // Disable is invoked by RunLoop via ShutdownSequence so it runs
+        // AFTER the stdin pump has stopped (issue #47). The `using` above
+        // is a safety net for the exception path: if RunLoop throws
+        // before reaching the shutdown sequence, Dispose still restores
+        // the terminal — it just lacks the synchronization guarantee
+        // because there's nothing left to synchronize with at that
+        // point.
+        RunLoop(engine, terminalMode);
         return 0;
     }
 
-    private static void RunLoop(GameEngine engine)
+    private static void RunLoop(GameEngine engine, TerminalMode terminalMode)
     {
         using var cts = new CancellationTokenSource();
         Console.CancelKeyPress += (_, e) =>
@@ -79,6 +79,33 @@ internal static class Program
 
         var events = Channel.CreateUnbounded<InputEvent>();
         var reader = Task.Run(() => PumpStdin(events.Writer, cts.Token));
+        try
+        {
+            DriveLiveLoop(engine, events, cts);
+        }
+        finally
+        {
+            events.Writer.TryComplete();
+            // Single ordered shutdown: cancel → wait for pump → restore
+            // terminal. Closes the tcsetattr/stdin.Read race from #47.
+            // The 250 ms timeout is the upper bound for the pump to
+            // observe cancellation under VTIME=1 (#50); under VTIME=0
+            // a parked read may not wake at all, in which case we
+            // still proceed to Disable rather than hang the user's
+            // shell — see ShutdownSequence for the trade-off.
+            ShutdownSequence.Run(
+                cancel: cts,
+                pumpTask: reader,
+                pumpJoinTimeout: TimeSpan.FromMilliseconds(250),
+                disable: () => terminalMode.Disable(Console.Out));
+        }
+    }
+
+    private static void DriveLiveLoop(
+        GameEngine engine,
+        Channel<InputEvent> events,
+        CancellationTokenSource cts)
+    {
         var stopwatch = Stopwatch.StartNew();
         var viewport = engine.BuildViewport(Console.WindowWidth, Console.WindowHeight);
         var initialBuffer = engine.Render(viewport, stopwatch.Elapsed);
@@ -112,17 +139,6 @@ internal static class Program
                     Thread.Sleep(16);
                 }
             });
-
-        cts.Cancel();
-        events.Writer.TryComplete();
-        try
-        {
-            reader.Wait(TimeSpan.FromMilliseconds(200));
-        }
-        catch
-        {
-            // Reader task may throw during shutdown; suppress.
-        }
     }
 
     private static void DrainEvents(

--- a/tests/TerminalSnake.Tests/Game/ShutdownSequenceTests.cs
+++ b/tests/TerminalSnake.Tests/Game/ShutdownSequenceTests.cs
@@ -1,0 +1,153 @@
+using System.Diagnostics;
+using TerminalSnake.Game;
+
+namespace TerminalSnake.Tests.Game;
+
+public sealed class ShutdownSequenceTests
+{
+    [Fact]
+    public void Disable_runs_after_pump_task_completes()
+    {
+        // Models the real shutdown: a pump task that only finishes
+        // once cancellation has been signalled, and a disable action
+        // that must NOT execute while the pump is still running.
+        var pumpTcs = new TaskCompletionSource();
+        var disableInvokedAt = (long?)null;
+        var pumpCompletedAt = (long?)null;
+        using var cts = new CancellationTokenSource();
+
+        cts.Token.Register(() =>
+        {
+            // Simulate the pump waking from its blocking read shortly
+            // after the cancellation token fires.
+#pragma warning disable xUnit1051 // shutdown is synchronous; test cancellation token irrelevant here.
+            Task.Run(async () =>
+            {
+                await Task.Delay(20).ConfigureAwait(false);
+                pumpCompletedAt = Stopwatch.GetTimestamp();
+                pumpTcs.SetResult();
+            });
+#pragma warning restore xUnit1051
+        });
+
+        ShutdownSequence.Run(
+            cancel: cts,
+            pumpTask: pumpTcs.Task,
+            pumpJoinTimeout: TimeSpan.FromSeconds(2),
+            disable: () => disableInvokedAt = Stopwatch.GetTimestamp());
+
+        Assert.True(pumpCompletedAt.HasValue, "Pump should have completed during shutdown");
+        Assert.True(disableInvokedAt.HasValue, "Disable should have been invoked");
+        Assert.True(
+            disableInvokedAt!.Value >= pumpCompletedAt!.Value,
+            "Disable must run only after the pump task has completed");
+    }
+
+    [Fact]
+    public void Cancellation_is_signalled_before_waiting_on_pump()
+    {
+        var pumpStarted = new ManualResetEventSlim(false);
+        var cancelObservedBeforeJoin = false;
+        using var cts = new CancellationTokenSource();
+
+#pragma warning disable xUnit1051 // background pump simulation; test cancellation token irrelevant.
+        var pumpTask = Task.Run(() =>
+        {
+            pumpStarted.Set();
+            // Spin until cancellation, then exit. If the sequence does
+            // NOT cancel before waiting, this task never completes and
+            // the join times out — test fails.
+            while (!cts.IsCancellationRequested)
+            {
+                Thread.Sleep(5);
+            }
+            cancelObservedBeforeJoin = true;
+        });
+#pragma warning restore xUnit1051
+
+        Assert.True(pumpStarted.Wait(TimeSpan.FromSeconds(2), TestContext.Current.CancellationToken));
+
+        ShutdownSequence.Run(
+            cancel: cts,
+            pumpTask: pumpTask,
+            pumpJoinTimeout: TimeSpan.FromSeconds(2),
+            disable: () => { });
+
+        Assert.True(pumpTask.IsCompleted, "Pump task must have completed before disable");
+        Assert.True(cancelObservedBeforeJoin, "Pump should have observed cancellation");
+    }
+
+    [Fact]
+    public void Disable_runs_even_when_pump_does_not_exit_within_timeout()
+    {
+        // Under VTIME=0 the pump can be stuck in a blocking read with
+        // no way to wake it. The shutdown sequence must still restore
+        // the terminal — leaving the tty in raw mode is worse than
+        // leaking a thread for a few ms.
+        using var cts = new CancellationTokenSource();
+        var stuckPump = new TaskCompletionSource().Task;
+        var disableInvoked = false;
+
+        ShutdownSequence.Run(
+            cancel: cts,
+            pumpTask: stuckPump,
+            pumpJoinTimeout: TimeSpan.FromMilliseconds(50),
+            disable: () => disableInvoked = true);
+
+        Assert.True(disableInvoked, "Disable must run even when the pump is stuck");
+    }
+
+    [Fact]
+    public void Disable_runs_after_pump_join_times_out_not_before()
+    {
+        using var cts = new CancellationTokenSource();
+        var stuckPump = new TaskCompletionSource().Task;
+        var startedAt = Stopwatch.GetTimestamp();
+        long disabledAt = 0;
+        var timeout = TimeSpan.FromMilliseconds(120);
+
+        ShutdownSequence.Run(
+            cancel: cts,
+            pumpTask: stuckPump,
+            pumpJoinTimeout: timeout,
+            disable: () => disabledAt = Stopwatch.GetTimestamp());
+
+        var elapsed = Stopwatch.GetElapsedTime(startedAt, disabledAt);
+        Assert.True(
+            elapsed >= timeout - TimeSpan.FromMilliseconds(20),
+            $"Disable should wait for the join timeout before running; elapsed {elapsed}");
+    }
+
+    [Fact]
+    public void Suppresses_pump_task_exception_so_disable_still_runs()
+    {
+        // The pump catches IO failures itself, but defence in depth:
+        // an exception bubbling out of the pump task must not stop
+        // the terminal from being restored.
+        using var cts = new CancellationTokenSource();
+        var faulted = Task.FromException(new InvalidOperationException("pump blew up"));
+        var disableInvoked = false;
+
+        ShutdownSequence.Run(
+            cancel: cts,
+            pumpTask: faulted,
+            pumpJoinTimeout: TimeSpan.FromMilliseconds(50),
+            disable: () => disableInvoked = true);
+
+        Assert.True(disableInvoked);
+    }
+
+    [Fact]
+    public void Throws_when_arguments_are_null()
+    {
+        using var cts = new CancellationTokenSource();
+        var task = Task.CompletedTask;
+
+        Assert.Throws<ArgumentNullException>(() =>
+            ShutdownSequence.Run(null!, task, TimeSpan.FromMilliseconds(10), () => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            ShutdownSequence.Run(cts, null!, TimeSpan.FromMilliseconds(10), () => { }));
+        Assert.Throws<ArgumentNullException>(() =>
+            ShutdownSequence.Run(cts, task, TimeSpan.FromMilliseconds(10), null!));
+    }
+}


### PR DESCRIPTION
## Summary
- Extract the shutdown ordering (cancel → bounded wait for pump → restore terminal) into a pure `ShutdownSequence` seam.
- `Program.RunLoop` now delegates shutdown to `ShutdownSequence.Run(cts, reader, 250 ms, () => terminalMode.Disable(...))` from a `finally`, so the order is guaranteed and a faulted/parked pump can no longer race `tcsetattr`.
- The 250 ms join is an explicit upper bound (documented), not a magic shrug — under VTIME=1 (post-#50) the pump exits in ~100 ms; under VTIME=0 we still restore the terminal rather than hang the user's shell.
- Live-loop body extracted into `DriveLiveLoop` to keep `RunLoop` readable.

Composes with #50 — VTIME values are intentionally not touched in this PR. Expect a tiny merge conflict against #50 in the shutdown wiring; trivial to resolve.

Closes #47

## Test plan
- [x] 6 new tests in `tests/TerminalSnake.Tests/Game/ShutdownSequenceTests.cs` pin: ordering (Disable after pump completes), pre-wait cancellation, bounded-wait fallback, faulted-pump suppression, null-arg guards.
- [x] Full suite: 324/324 pass.
- [x] `bash scripts/quality-gate.sh` → PASSED (line 96 %, branch 92.4 %).