### PR TITLE
fix(input): flush parser on idle so bare ESC emits a key event

### DIFF
--- a/src/TerminalSnake.App/Input/StdinInputLoop.cs
+++ b/src/TerminalSnake.App/Input/StdinInputLoop.cs
@@ -1,0 +1,86 @@
+namespace TerminalSnake.Input;
+
+// Reads bytes from <paramref name="stream"/> in a loop and turns them into
+// InputEvents via BufferedInputParser. The loop's reason for existing is
+// issue #44: a bare ESC (0x1B) is ambiguous on a terminal — it might be a
+// standalone Escape keypress or the first byte of a CSI/SS3 sequence. The
+// parser only commits the bare ESC as <see cref="ConsoleKey.Escape"/> when
+// it's told the input has been flushed. Real stdin never naturally raises
+// such a signal, so we synthesise it here whenever a read times out (the
+// idle window is shorter than any human follow-up keystroke would be) or
+// when the stream reaches EOF.
+public static class StdinInputLoop
+{
+    public static async Task RunAsync(
+        Stream stream,
+        TimeSpan idleTimeout,
+        Action<InputEvent> emit,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(stream);
+        ArgumentNullException.ThrowIfNull(emit);
+
+        var parser = new BufferedInputParser();
+        var buffer = new byte[128];
+
+        while (!cancellationToken.IsCancellationRequested)
+        {
+            var read = await ReadOnceAsync(stream, buffer, idleTimeout, cancellationToken)
+                .ConfigureAwait(false);
+            if (read.IsCancelled)
+            {
+                break;
+            }
+            if (read.IsEof)
+            {
+                EmitEvents(parser.Feed(ReadOnlySpan<byte>.Empty, inputFlushed: true), emit);
+                break;
+            }
+            EmitEvents(FeedParser(parser, buffer, read.Count), emit);
+        }
+    }
+
+    private static IReadOnlyList<InputEvent> FeedParser(
+        BufferedInputParser parser, byte[] buffer, int count)
+    {
+        if (count > 0)
+        {
+            return parser.Feed(buffer.AsSpan(0, count));
+        }
+        return parser.Feed(ReadOnlySpan<byte>.Empty, inputFlushed: true);
+    }
+
+    private static void EmitEvents(IReadOnlyList<InputEvent> events, Action<InputEvent> emit)
+    {
+        for (var i = 0; i < events.Count; i++)
+        {
+            emit(events[i]);
+        }
+    }
+
+    private static async Task<ReadResult> ReadOnceAsync(
+        Stream stream, byte[] buffer, TimeSpan idleTimeout, CancellationToken cancellationToken)
+    {
+        using var idle = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        idle.CancelAfter(idleTimeout);
+        try
+        {
+            var count = await stream.ReadAsync(buffer.AsMemory(), idle.Token).ConfigureAwait(false);
+            return count == 0 ? ReadResult.Eof : ReadResult.Bytes(count);
+        }
+        catch (OperationCanceledException)
+        {
+            return cancellationToken.IsCancellationRequested
+                ? ReadResult.Cancelled
+                : ReadResult.IdleTimeout;
+        }
+    }
+
+    private readonly record struct ReadResult(int Count, bool IsEof, bool IsCancelled, bool IsIdle)
+    {
+        public static ReadResult Bytes(int count) => new(count, false, false, false);
+        public static ReadResult Eof { get; } = new(0, true, false, false);
+        public static ReadResult Cancelled { get; } = new(0, false, true, false);
+        public static ReadResult IdleTimeout { get; } = new(0, false, false, true);
+    }
+}

--- a/src/TerminalSnake.App/Program.cs
+++ b/src/TerminalSnake.App/Program.cs
@@ -78,7 +78,7 @@ internal static class Program
         };
 
         var events = Channel.CreateUnbounded<InputEvent>();
-        var reader = Task.Run(() => PumpStdin(events.Writer, cts.Token));
+        var reader = Task.Run(() => PumpStdin(events.Writer, cts.Token), cts.Token);
         var stopwatch = Stopwatch.StartNew();
         var viewport = engine.BuildViewport(Console.WindowWidth, Console.WindowHeight);
         var initialBuffer = engine.Render(viewport, stopwatch.Elapsed);
@@ -169,37 +169,21 @@ internal static class Program
         ((click.Column - viewport.BoardOriginX) / ViewportCalculator.CellCharWidth,
          (click.Row - viewport.BoardOriginY) / ViewportCalculator.CellCharHeight);
 
-    private static void PumpStdin(ChannelWriter<InputEvent> writer, CancellationToken ct)
+    // 50 ms is well below any realistic CSI follow-up latency (locally <1 ms,
+    // <10 ms over typical SSH) but well above human reaction time. Long enough
+    // that ESC + [ + A still parses as ↑; short enough that a bare Esc keypress
+    // resolves before the next render frame.
+    private static readonly TimeSpan EscapeIdleFlush = TimeSpan.FromMilliseconds(50);
+
+    private static Task PumpStdin(ChannelWriter<InputEvent> writer, CancellationToken ct)
     {
-        var parser = new BufferedInputParser();
         var stdin = OperatingSystem.IsWindows()
             ? Console.OpenStandardInput()
             : PosixTerminal.OpenTtyReadStream();
-        var buffer = new byte[128];
-        while (!ct.IsCancellationRequested)
-        {
-            int read;
-            try
-            {
-                read = stdin.Read(buffer, 0, buffer.Length);
-            }
-            catch
-            {
-                break;
-            }
-            if (read == 0)
-            {
-                Thread.Sleep(10);
-                continue;
-            }
-            var events = parser.Feed(buffer.AsSpan(0, read));
-            foreach (var evt in events)
-            {
-                if (!writer.TryWrite(evt))
-                {
-                    return;
-                }
-            }
-        }
+        return StdinInputLoop.RunAsync(
+            stdin,
+            EscapeIdleFlush,
+            evt => writer.TryWrite(evt),
+            ct);
     }
 }

--- a/tests/TerminalSnake.Tests/Input/ControllableStream.cs
+++ b/tests/TerminalSnake.Tests/Input/ControllableStream.cs
@@ -1,0 +1,73 @@
+using System.Threading.Channels;
+
+namespace TerminalSnake.Tests.Input;
+
+// Stream test double that lets the test push bytes from the outside and
+// observe when the consumer has read them. Each PostBytes call enqueues a
+// single chunk; ReadAsync awaits the next chunk (or EOF). This lets tests
+// drive StdinInputLoop synchronously without timing on real stdin.
+internal sealed class ControllableStream : Stream
+{
+    private readonly Channel<byte[]?> _chunks = Channel.CreateUnbounded<byte[]?>();
+    private byte[]? _residual;
+    private int _residualOffset;
+    private TaskCompletionSource _drained = NewDrainedSignal();
+
+    public override bool CanRead => true;
+    public override bool CanSeek => false;
+    public override bool CanWrite => false;
+    public override long Length => throw new NotSupportedException();
+    public override long Position
+    {
+        get => throw new NotSupportedException();
+        set => throw new NotSupportedException();
+    }
+
+    public void PostBytes(byte[] bytes)
+    {
+        _drained = NewDrainedSignal();
+        _chunks.Writer.TryWrite(bytes);
+    }
+
+    public void SignalEof() => _chunks.Writer.TryWrite(null);
+
+    // Resolves the next time the consumer has consumed every byte we posted.
+    public Task WaitUntilDrainedAsync() => _drained.Task;
+
+    public override async ValueTask<int> ReadAsync(
+        Memory<byte> buffer, CancellationToken cancellationToken = default)
+    {
+        if (_residual is null)
+        {
+            var chunk = await _chunks.Reader.ReadAsync(cancellationToken).ConfigureAwait(false);
+            if (chunk is null)
+            {
+                return 0;
+            }
+            _residual = chunk;
+            _residualOffset = 0;
+        }
+        var available = _residual.Length - _residualOffset;
+        var copy = Math.Min(available, buffer.Length);
+        _residual.AsSpan(_residualOffset, copy).CopyTo(buffer.Span);
+        _residualOffset += copy;
+        if (_residualOffset == _residual.Length)
+        {
+            _residual = null;
+            _residualOffset = 0;
+            _drained.TrySetResult();
+        }
+        return copy;
+    }
+
+    public override int Read(byte[] buffer, int offset, int count) =>
+        ReadAsync(buffer.AsMemory(offset, count)).AsTask().GetAwaiter().GetResult();
+
+    public override void Flush() { }
+    public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    private static TaskCompletionSource NewDrainedSignal() =>
+        new(TaskCreationOptions.RunContinuationsAsynchronously);
+}

--- a/tests/TerminalSnake.Tests/Input/StdinInputLoopTests.cs
+++ b/tests/TerminalSnake.Tests/Input/StdinInputLoopTests.cs
@@ -1,0 +1,81 @@
+using TerminalSnake.Input;
+
+namespace TerminalSnake.Tests.Input;
+
+// Drives StdinInputLoop with a controllable in-memory stream so we can
+// exercise the idle-flush path without real stdin or real wall-clock waits.
+// The loop's contract is: a read that completes with bytes feeds the parser
+// without flushing; a read that times out (no input within the idle window)
+// flushes the parser; a read that returns 0 (EOF) flushes once and exits.
+public sealed class StdinInputLoopTests
+{
+    [Fact]
+    public async Task Bare_escape_emits_escape_after_idle_flush()
+    {
+        var stream = new ControllableStream();
+        var emitted = new List<InputEvent>();
+        var idle = TimeSpan.FromMilliseconds(20);
+        using var lifetime = new CancellationTokenSource();
+
+        var loop = StdinInputLoop.RunAsync(stream, idle, evt => emitted.Add(evt), lifetime.Token);
+
+        stream.PostBytes(new byte[] { 0x1B });
+        await stream.WaitUntilDrainedAsync();
+        // No second byte arrives within the idle window -> loop must flush.
+        await Task.Delay(idle + TimeSpan.FromMilliseconds(80), TestContext.Current.CancellationToken);
+
+        lifetime.Cancel();
+        stream.SignalEof();
+        await loop;
+
+        Assert.Contains(new KeyEvent(ConsoleKey.Escape), emitted);
+    }
+
+    [Fact]
+    public async Task Eof_flushes_pending_bare_escape_before_exit()
+    {
+        var stream = new ControllableStream();
+        var emitted = new List<InputEvent>();
+        using var lifetime = new CancellationTokenSource();
+
+        var loop = StdinInputLoop.RunAsync(
+            stream, TimeSpan.FromSeconds(5), evt => emitted.Add(evt), lifetime.Token);
+
+        stream.PostBytes(new byte[] { 0x1B });
+        await stream.WaitUntilDrainedAsync();
+        stream.SignalEof();
+
+        await loop;
+
+        Assert.Contains(new KeyEvent(ConsoleKey.Escape), emitted);
+    }
+
+    [Fact]
+    public async Task Plain_byte_emits_immediately_without_waiting_for_idle()
+    {
+        var stream = new ControllableStream();
+        var emitted = new List<InputEvent>();
+        using var lifetime = new CancellationTokenSource();
+
+        var loop = StdinInputLoop.RunAsync(
+            stream, TimeSpan.FromSeconds(5), evt => emitted.Add(evt), lifetime.Token);
+
+        stream.PostBytes(new byte[] { (byte)'q' });
+        await stream.WaitUntilDrainedAsync();
+
+        // Give the loop a brief moment to deliver the event; nowhere near
+        // the 5 s idle timeout so a passing test means no idle-flush path
+        // was needed.
+        var deadline = DateTime.UtcNow.AddSeconds(2);
+        while (emitted.Count == 0 && DateTime.UtcNow < deadline)
+        {
+            await Task.Delay(5, TestContext.Current.CancellationToken);
+        }
+
+        lifetime.Cancel();
+        stream.SignalEof();
+        await loop;
+
+        Assert.Equal(new KeyEvent(ConsoleKey.Q), Assert.Single(emitted));
+    }
+}


### PR DESCRIPTION
## Summary
- Replace the hand-rolled stdin read loop in `Program.PumpStdin` with `StdinInputLoop.RunAsync`, which races each `ReadAsync` against a 50 ms idle cancellation window.
- On idle timeout (or EOF), the parser is fed an empty buffer with `inputFlushed: true`, draining any pending bare `0x1B` so a lone Esc resolves to `ConsoleKey.Escape`.
- 50 ms is long enough that `ESC [ A` still parses as Up Arrow on local + typical SSH terminals, short enough that a quit Esc resolves before the next render frame.
- The parser side (`InputDecoder`/`BufferedInputParser`) was already correct — only the read-side flush trigger was missing.

Closes #44

## Test plan
- [x] 3 new facts in `tests/TerminalSnake.Tests/Input/StdinInputLoopTests.cs` (idle-flush emits Escape; EOF flush before exit; plain bytes emit immediately) using a `ControllableStream` test fake. RED before, GREEN after.
- [x] Full suite: 321/321 pass.
- [x] `bash scripts/quality-gate.sh` → PASSED. New `StdinInputLoop` at 100 % line coverage.